### PR TITLE
read complete http response

### DIFF
--- a/util.go
+++ b/util.go
@@ -23,7 +23,10 @@ func apiRequest(nodeClient chef.Client, method, url string, data io.Reader) (*ht
 		fmt.Println(err)
 	}
 	defer res.Body.Close()
-	// res.Body.Close()
+
+	if res.StatusCode == 200 {
+		ioutil.ReadAll(res.Body)
+	}
 	return res, err
 }
 


### PR DESCRIPTION
when making requests that result in http encoding chunked,
the client would only read the first few bytes before giving
up, and the server did not end up doing the work to serve
the entire request. this change ensures that the client
simulates a full request, including streaming all of the
data back to the requestor

Signed-off-by: Stephen Delano <stephen@chef.io>