### PR TITLE
Adding option to generate client

### DIFF
--- a/chef-client-run.go
+++ b/chef-client-run.go
@@ -39,6 +39,19 @@ func chefClientRun(nodeClient chef.Client, nodeName string, getCookbooks bool, o
 		ohaiJSON["ipaddress"] = "169.254.169.254"
 	}
 
+	if config.RunChefClient && config.CreateClients {
+		_, err = nodeClient.Clients.Get(nodeName)
+		if err != nil {
+			statusCode := getStatusCode(err)
+			if statusCode == 404 {
+				_, err = nodeClient.Clients.Create(nodeName, false)
+				if err != nil {
+					fmt.Println("Couldn't create client", err)
+				}
+			}
+		}
+	}
+
 	if config.RunChefClient {
 		node, err = nodeClient.Nodes.Get(nodeName)
 		if err != nil {

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type chefLoadConfig struct {
 	DownloadCookbooks        string
 	APIGetRequests           []string `toml:"api_get_requests"`
 	EnableReporting          bool
+	CreateClients            bool
 }
 
 func printSampleConfig() {
@@ -127,6 +128,11 @@ func printSampleConfig() {
 
 # Send data to the Chef server's Reporting service
 # enable_reporting = false
+
+# Create clients for each node. 
+# This is useful if you need to generate load to simulate validator key based bootstrapping.
+# Note that the client generated will not actually be used in any requests.
+# create_clients = false
 `
 	fmt.Print(sampleConfig)
 }
@@ -167,6 +173,7 @@ func loadConfig(file string) (*chefLoadConfig, error) {
 
 		DownloadCookbooks: "never",
 		EnableReporting:   false,
+		CreateClients:     false,
 	}
 
 	if err = toml.NewDecoder(f).Decode(&config); err != nil {


### PR DESCRIPTION
Adds a `create_clients` config option that will generate a new client
on the Chef server if one does not exist.  The client will not be
saved/used for any future API requests.  This only to generate the load
of creating client keys on the server.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>