### PR TITLE
[ChefActions] Generate 10 Chef Actions with flag -chef-action

### DIFF
--- a/chef_actions.go
+++ b/chef_actions.go
@@ -1,0 +1,239 @@
+//
+// Copyright:: Copyright 2017 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+var entityNameList = map[int]string{
+	0: "nginx",
+	1: "apache",
+	2: "burger",
+	3: "salsa",
+}
+
+var requestorNameList = map[int]string{
+	0: "kyleen",
+	1: "localhost", // This is a chef-zero run
+	2: "knife",
+	3: "rad",
+	4: "lance",
+	5: "afiune",
+}
+
+var serviceHostnameList = map[int]string{
+	0: "hostname",
+	1: "localhost",
+	2: "chef.example.com",
+	3: "my.awesome.hostname.com",
+}
+
+var organizationNameList = map[int]string{
+	0: "awesome",
+	1: "_default",
+	2: "development",
+	3: "staging",
+	4: "production",
+}
+
+// ActionType will be our enum to identity a list of actions types
+type ActionType int
+
+// Supported Action Types (EntityType)
+const (
+	nodeAction ActionType = iota
+	cookbookAction
+	dataBagAction
+	environmentAction
+	roleAction
+	policyfileAction
+	// TODO: (@afiune) Add latter when compliance joins the pool party
+	//profileAction
+	//scanJobsAction
+)
+
+// Strings of the supported Action Type list above
+var actionTypeString = map[ActionType]string{
+	nodeAction:        "node",
+	cookbookAction:    "cookbook",
+	dataBagAction:     "bag",
+	environmentAction: "environment",
+	roleAction:        "role",
+	policyfileAction:  "policyfile",
+
+	// In the RFC we have more action/entity types
+	// https://github.com/chef/chef-rfc/blob/master/rfc077-mode-agnostic-data-collection.md#action-schema
+	// TODO: (@afiune) How do we handle those?
+	//"user",
+	//"permission",
+	//"item",
+	//"group",
+	//"client",
+
+	// TODO: (@afiune) Add latter when compliance joins the pool party
+	//profileAction:     "profile",
+	//scanJobsAction:    "scanjobs",
+}
+
+// Task will be our enum to identity a list of tasks
+type Task int
+
+// Supported Tasks
+const (
+	createTask Task = iota
+	editTask
+	deleteTask
+)
+
+// Strings of the supported Tasks list above
+var tasksString = map[Task]string{
+	createTask: "create",
+	editTask:   "edit",
+	deleteTask: "delete",
+}
+
+type actionRequest struct {
+	ID               uuid.UUID   `json:"id"`
+	MessageType      string      `json:"message_type"`
+	MessageVersion   string      `json:"message_version"`
+	EntityType       string      `json:"entity_type"`
+	actionType       ActionType  `json:"-"`
+	EntityName       string      `json:"entity_name"`
+	Task             string      `json:"task"`
+	OrganizationName string      `json:"organization_name"`
+	ServiceHostname  string      `json:"service_hostname"`
+	RecordedAt       time.Time   `json:"recorded_at"`
+	RemoteHostname   string      `json:"remote_hostname"`
+	RequestID        string      `json:"request_id"`
+	RequestorName    string      `json:"requestor_name"`
+	RequestorType    string      `json:"requestor_type"`
+	UserAgent        string      `json:"user_agent"`
+	RemoteRequestID  string      `json:"remote_request_id,omitempty"`
+	Data             interface{} `json:"data"`
+}
+
+func defaultActionRequest() *actionRequest {
+	return &actionRequest{
+		ID:               uuid.NewV4(),
+		MessageType:      "action",
+		MessageVersion:   "0.1.0",
+		actionType:       nodeAction,
+		EntityType:       actionTypeString[nodeAction],
+		EntityName:       "",
+		Task:             "",
+		OrganizationName: "_default",
+		ServiceHostname:  "",
+		RecordedAt:       time.Now(),
+		RemoteHostname:   "",
+		RequestID:        "",
+		RequestorName:    "",
+		RequestorType:    "chef-load",
+		UserAgent:        "chef-load-4.0.0", // Create a version?
+		RemoteRequestID:  "",
+		Data:             map[string]string{},
+	}
+}
+
+func newActionRequest(aType ActionType) *actionRequest {
+	a := defaultActionRequest()
+	a.SetEntityType(aType)
+	return a
+}
+
+func newRandomActionRequest(aType ActionType) *actionRequest {
+	a := newActionRequest(aType)
+	a.randomize()
+	return a
+}
+
+func randomActionType() ActionType {
+	return ActionType(rand.Intn(len(actionTypeString)))
+}
+
+func randomTask() Task {
+	return Task(rand.Intn(len(tasksString)))
+}
+
+func (ar *actionRequest) SetTask(t Task) {
+	ar.Task = tasksString[t]
+}
+
+func (ar *actionRequest) SetEntityType(t ActionType) {
+	ar.actionType = t
+	ar.EntityType = actionTypeString[t]
+}
+
+func randomEntityName() string {
+	return entityNameList[rand.Intn(len(entityNameList))]
+}
+
+func randomRequestorName() string {
+	return requestorNameList[rand.Intn(len(requestorNameList))]
+}
+
+func randomServiceHostname() string {
+	return serviceHostnameList[rand.Intn(len(serviceHostnameList))]
+}
+
+func randomOrganizationName() string {
+	return organizationNameList[rand.Intn(len(organizationNameList))]
+}
+
+func randomTime() time.Time {
+	return time.Now().AddDate(0, 0, rand.Intn(7)*-1)
+}
+
+// This function will randomize the Chef Action instance depending on the action type
+func (ar *actionRequest) randomize() {
+	ar.SetTask(randomTask())
+	ar.EntityName = randomEntityName()
+	ar.RequestorName = randomRequestorName()
+	ar.ServiceHostname = randomServiceHostname()
+	ar.OrganizationName = randomOrganizationName()
+	ar.RecordedAt = randomTime()
+
+	// Custom settings for specific actions
+	//
+	// We might use this if we have to customize specific fields for each action type
+	switch ar.actionType {
+	case nodeAction:
+	case cookbookAction:
+	case dataBagAction:
+	case environmentAction:
+	case roleAction:
+	case policyfileAction:
+	// TODO: (@afiune) Add latter when compliance joins the pool party
+	//case profileAction:
+	//case scanJobsAction:
+	default:
+	}
+}
+
+func (ar *actionRequest) String() string {
+	return fmt.Sprintf("%s::%s", ar.EntityType, ar.Task)
+}
+
+func chefAction(aType ActionType) error {
+	action := newRandomActionRequest(aType)
+	return chefAutomateSendMessage(action.String(), config.DataCollectorToken, config.DataCollectorURL, action)
+}

--- a/config.go
+++ b/config.go
@@ -47,6 +47,7 @@ type chefLoadConfig struct {
 	ChefServerCreatesClientKey bool `toml:chef_server_creates_client_key`
 	EnableReporting            bool
 	RandomData                 bool
+	ChefAction                 bool
 }
 
 func defaultConfig() chefLoadConfig {
@@ -70,6 +71,7 @@ func defaultConfig() chefLoadConfig {
 		ChefServerCreatesClientKey: false,
 		EnableReporting:            false,
 		RandomData:                 false,
+		ChefAction:                 false,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"math"
+	"math/rand"
 	"os"
 	"os/signal"
 	"path"
@@ -55,7 +56,13 @@ func init() {
 	fSampleConfig := flag.Bool("sample-config", false, "Print out full sample configuration")
 	fProfileLogs := flag.Bool("profile-logs", false, "Generates API request profile from specified chef-load log files")
 	fVersion := flag.Bool("version", false, "Print chef-load version")
+	// Turn this into a command
 	fRandomData := flag.Bool("random-data", false, "Generates random data")
+	// Turn this into a command
+	//
+	// For now and until @afiune refactors this project to introduce commands using our standard
+	// libraries (cobra/viper) we will push 10 random actions.
+	fChefAction := flag.Bool("chef-action", false, "Generates 10 Chef Actions")
 	flag.Parse()
 
 	if *fHelp {
@@ -92,6 +99,10 @@ func init() {
 	config, err = loadConfig(*fConfig)
 	if err != nil {
 		log.WithField("error", err).Fatal("Could not load chef-load config file")
+	}
+
+	if *fChefAction {
+		config.ChefAction = true
 	}
 
 	if *fRandomData {
@@ -193,6 +204,27 @@ func main() {
 			}
 		}
 	}()
+
+	if config.ChefAction {
+		// TODO: (@afiune) Re design a bit more to have different use-cases, maybe sub-commands?
+		//
+		// 1) Start the Chef-Load service for continous data:
+		//       chef-load start -config foo.conf
+		// 2) Load one time data with random fields:
+		//       (NODES):   chef-load generate nodes 100 -config foo.conf
+		//       (ACTIONS): chef-load generate actions 100 -config foo.conf
+		// 3) Initialize the chef-load conig
+		//       chef-load init
+		//
+		// For now we just have one flag -chef-action to land in this if
+		fmt.Printf("Loading 10 Chef Actions")
+		rand.Seed(time.Now().UTC().UnixNano())
+		for i := 1; i <= 10; i++ {
+			// TODO: Check the errors
+			chefAction(randomActionType())
+		}
+		os.Exit(0)
+	}
 
 	if config.RandomData {
 		// TODO: (@afiune) Re design a bit more to have different use-cases, maybe sub-commands?


### PR DESCRIPTION
# Ready for Review!

![tenor-210660557](https://user-images.githubusercontent.com/5712253/34274809-34a44c98-e64f-11e7-8dfb-6eda0c241939.gif)

This PR is adding a new functionality to chef-load to generate 10 chef-actions, you just have to add the flag `-chef-action` and the config to set the `data_collector` url and token. 👍 

Right now the number of actions is fixed to 10 because chef-load is based in node load, we need to do a refactor where we have types of loads but I wanted to have the smallest possible change to generate data to Automate 2.0. 

Example config:
```
data_collector_url = "https://localhost:2000/events/data-collector"
data_collector_token = "dev"
```

Example command:
```
$ chef-load -config /tmp/config -chef-action
Loading 10 Chef Actions%
```

Signed-off-by: Salim Afiune <afiune@chef.io>