### PR TITLE
[AIA-103] Ability to load X days of back data

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -21,6 +21,7 @@ import (
 	chef_load "github.com/chef/chef-load/lib"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var generateCmd = &cobra.Command{
@@ -41,4 +42,6 @@ var generateCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
+	generateCmd.Flags().Int("days_back", 0, "The number days back for historical data")
+	viper.BindPFlags(generateCmd.Flags())
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -51,11 +51,13 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.chef-load.toml)")
 	rootCmd.PersistentFlags().StringP("data_collector_url", "d", "", "The data-collector url")
+	// TODO: add the token flag for the data collector
 	rootCmd.PersistentFlags().StringP("chef_server_url", "s", "", "The chef-server url")
 	rootCmd.PersistentFlags().StringP("node_name_prefix", "p", "chef-load", "The nodes name prefix")
 	rootCmd.PersistentFlags().IntP("num_nodes", "n", 0, "The number of nodes to simulate")
 	rootCmd.PersistentFlags().IntP("num_actions", "a", 0, "The number of actions to generate")
 	rootCmd.PersistentFlags().BoolP("random_data", "r", false, "Generates random data")
+	rootCmd.PersistentFlags().IntP("interval", "i", 30, "Interval between a node's chef-client runs, in minutes")
 	viper.BindPFlags(rootCmd.PersistentFlags())
 }
 

--- a/commands/start.go
+++ b/commands/start.go
@@ -42,7 +42,6 @@ var startCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(startCmd)
-	startCmd.Flags().IntP("interval", "i", 30, "Interval between a node's chef-client runs, in minutes")
 	startCmd.Flags().Bool("profile-logs", false, "Generates API request profile from specified chef-load log files")
 	viper.BindPFlags(startCmd.Flags())
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	ChefServerCreatesClientKey bool     `mapstructure:"chef_server_creates_client_key"`
 	RandomData                 bool     `mapstructure:"random_data"`
 	EnableReporting            bool     `mapstructure:"enable_reporting"`
+	DaysBack                   int      `mapstructure:"days_back"`
 }
 
 func Default() Config {
@@ -69,6 +70,7 @@ func Default() Config {
 		EnableReporting:            false,
 		RandomData:                 false,
 		NumActions:                 30,
+		DaysBack:                   0,
 	}
 }
 
@@ -141,6 +143,10 @@ func PrintSampleConfig() {
 # the amount of time a Chef Client takes actually converging all of the run list's resources.
 # sleep_duration is measured in seconds
 # sleep_duration = 0
+
+# days_back is an optional setting that allows the load of historical data. When provided, the tool
+# will use this value to load the data from today to the provided day back.
+# days_back = 30
 
 # download_cookbooks controls which chef-client run downloads cookbook files.
 # Options are: "never", "first" (first chef-client run only), "always"


### PR DESCRIPTION
This commit is giving chef-load the ability to load a number of days of
back data to the system.

We calculate how many chef-client runs we need to trigger, an example
would be:

For 10 nodes with 30 days of back data converging every 30 minutes
`1440m / 30m = 40 (CCR a day) * 30d = 1200 (Total CCRs per Node) * 10 = 12000`

The command you would use is:
```
chef-load generate -d localhost:2000 -n 10 -i 30 --days_back 30
```

Signed-off-by: Salim Afiune <afiune@chef.io>