### PR TITLE
[BugFix] Set StartTime for the generate command

### DIFF
--- a/lib/generator.go
+++ b/lib/generator.go
@@ -205,6 +205,8 @@ func genStartEndTime(config *Config) (time.Time, time.Time) {
 		hours := rand.Intn(config.DaysBack) * 24
 		historyDuration, _ := time.ParseDuration(fmt.Sprintf("%dh", hours))
 		sTime = time.Now().UTC().Add(-historyDuration).UTC()
+	} else {
+		sTime = time.Now().UTC()
 	}
 	minutes := rand.Intn(60)
 	randDuration, _ := time.ParseDuration(fmt.Sprintf("%dm", minutes))


### PR DESCRIPTION
This commit fixes the problem where we dont set a StartTime when we
don't provide the --days flag to load historical data.

Signed-off-by: Salim Afiune <afiune@chef.io>