### PR TITLE
AIA-186 Add a delay for Historical Data

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -43,7 +43,7 @@ var generateCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(generateCmd)
 	generateCmd.Flags().Int("days_back", 0, "The number days back for historical data")
-	generateCmd.Flags().Int("chan_size", 3000, "Number of simultaneous goroutines to spawn for historical data")
-	generateCmd.Flags().Int("sleep_time_of_failure", 5, "Time in seconds to sleep when a failure is detected for historical data")
+	generateCmd.Flags().Int("threads", 3000, "Number of simultaneous goroutines to spawn for historical data")
+	generateCmd.Flags().Int("sleep_time_on_failure", 5, "Time in seconds to sleep when a failure is detected for historical data")
 	viper.BindPFlags(generateCmd.Flags())
 }

--- a/commands/generate.go
+++ b/commands/generate.go
@@ -43,5 +43,7 @@ var generateCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(generateCmd)
 	generateCmd.Flags().Int("days_back", 0, "The number days back for historical data")
+	generateCmd.Flags().Int("chan_size", 3000, "Number of simultaneous goroutines to spawn for historical data")
+	generateCmd.Flags().Int("sleep_time_of_failure", 5, "Time in seconds to sleep when a failure is detected for historical data")
 	viper.BindPFlags(generateCmd.Flags())
 }

--- a/lib/chef_actions.go
+++ b/lib/chef_actions.go
@@ -221,7 +221,7 @@ func GenerateChefActions(config *Config, requests chan *request) error {
 	return nil
 }
 
-func chefAction(config *Config, aType ActionType, dataCollectorClient *DataCollectorClient) error {
+func chefAction(config *Config, aType ActionType, dataCollectorClient *DataCollectorClient) (int, error) {
 	action := newRandomActionRequest(aType)
 	return chefAutomateSendMessage(dataCollectorClient, action.String(), action)
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	RandomData                 bool     `mapstructure:"random_data"`
 	EnableReporting            bool     `mapstructure:"enable_reporting"`
 	DaysBack                   int      `mapstructure:"days_back"`
+	Threads                    int      `mapstructure:"threads"`
+	SleepTimeOnFailure         int      `mapstructure:"sleep_time_on_failure"`
 }
 
 func Default() Config {
@@ -71,6 +73,8 @@ func Default() Config {
 		RandomData:                 false,
 		NumActions:                 30,
 		DaysBack:                   0,
+		Threads:                    3000,
+		SleepTimeOnFailure:         5,
 	}
 }
 

--- a/lib/data_collector.go
+++ b/lib/data_collector.go
@@ -137,9 +137,13 @@ func (dcc *DataCollectorClient) Update(nodeName string, body interface{}) (*http
 	return res, err
 }
 
-func chefAutomateSendMessage(client *DataCollectorClient, nodeName string, body interface{}) error {
-	_, err := client.Update(nodeName, body)
-	return err
+func chefAutomateSendMessage(client *DataCollectorClient, nodeName string, body interface{}) (int, error) {
+	code := 999
+	res, err := client.Update(nodeName, body)
+	if res != nil {
+		code = res.StatusCode
+	}
+	return code, err
 }
 
 func dataCollectorRunStart(config *Config, nodeName, chefServerFQDN, orgName string,

--- a/lib/generator.go
+++ b/lib/generator.go
@@ -69,7 +69,7 @@ func GenerateCCRs(config *Config, requests chan *request) (err error) {
 		c            int64 = 0
 		ccrsIngested int64 = 0
 		ccrsRejected int64 = 0
-		loops        int   = 1
+		batches      int   = 1
 		code         int   = 999
 		rejects      bool  = false
 		timeMarker         = time.Now()
@@ -104,15 +104,15 @@ func GenerateCCRs(config *Config, requests chan *request) (err error) {
 	// Lets try to use a smaller number of goroutines
 	if config.NumNodes > config.Threads {
 		// If the number of nodes is bigger than the channel
-		// size, lets calculate how many loops we need to run
-		loops = config.NumNodes / config.Threads
+		// size, lets calculate how many batches we need to run
+		batches = config.NumNodes / config.Threads
 	}
 
 	// For the total of CCRs per node, run a converge
 	for c = 0; c < ccrsTotal; c++ {
 
-		// Loops * config.Threads = NumNodes (ish)
-		for j := 0; j < loops; j++ {
+		// batches * config.Threads = NumNodes (ish)
+		for j := 0; j < batches; j++ {
 
 			for i := 0; i < config.Threads; i++ {
 				nodeNum := i + (j * config.Threads)

--- a/lib/generator.go
+++ b/lib/generator.go
@@ -24,7 +24,6 @@ package chef_load
 import (
 	"errors"
 	"fmt"
-	"math"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -106,7 +105,10 @@ func GenerateCCRs(config *Config, requests chan *request) (err error) {
 	if config.NumNodes > config.Threads {
 		// If the number of nodes is bigger than the channel
 		// size, lets calculate how many batches we need to run
-		batches = int(math.Ceil(float64(config.NumNodes) / float64(config.Threads)))
+		batches = int(config.NumNodes / config.Threads)
+		if config.NumNodes%config.Threads != 0 {
+			batches++
+		}
 		channels = make([]<-chan int, config.Threads)
 	} else {
 		channels = make([]<-chan int, config.NumNodes)


### PR DESCRIPTION
This PR is enabling chef-load to have a delay when we execute the `chef-load generate --days_back X` command. Before we were blasting the system with an infinite loop of requests, now the system is smart to detect failures and sleep for the provided amount of time so that A2 can release pressure in the ingestion pipeline.

Example of the execution:
```
$ chef-load generate --config chef-load.toml -n 10000 --threads 4000 --days_back 30 --sleep_time_on_failure 15
```

This command will ingest 10k nodes with 30 days of historical data, ingesting 4,000 threads and checking each batch for failures, if a failure was found, chef-load will wait 15 sec before resuming the ingestion.

# Next steps
One thing we could do next is to make chef-load smarter so that it increases the sleep time depending of how often there are failures per batch. Think about it as if you were to find the right about of time that the system needs to ingest all the messages that it has buffered. 

Signed-off-by: Salim Afiune <afiune@chef.io>