### PR TITLE
Random action times

### DIFF
--- a/lib/chef_actions.go
+++ b/lib/chef_actions.go
@@ -177,7 +177,7 @@ func randomCookbookVersion() string {
 }
 
 func randomTime() time.Time {
-	return time.Now().AddDate(0, 0, rand.Intn(7)*-1)
+	return time.Now().Add(time.Duration(-int(time.Hour) * rand.Intn(7*24)))
 }
 
 // This function will randomize the Chef Action instance depending on the action type


### PR DESCRIPTION
Updated the random time of the actions to include the hours between a
day. Before the date for an action would be the same hour but a
different day for the past 7 days. Now the date will be any hour for the
past 7 days.

Before:
<img width="1435" alt="screen shot 2018-05-22 at 2 19 26 pm" src="https://user-images.githubusercontent.com/1679247/40389546-f82d9262-5dcf-11e8-8583-57b54ce7c19e.png">

After:
<img width="1425" alt="screen shot 2018-05-22 at 2 48 58 pm" src="https://user-images.githubusercontent.com/1679247/40389566-02e9ffb0-5dd0-11e8-976d-8f60e3d02052.png">


Signed-off-by: Lance Finfrock <lfinfrock@chef.io>