### PR TITLE
add documentation to readme for running on ec2

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -2,6 +2,8 @@
 hab pkg install chef/ci-studio-common
 source "$(hab pkg path chef/ci-studio-common)/bin/studio-common"
 
+
+
 document "go_build_chef_load" <<DOC
   Builds chef-load/main.go into /src/bin/chef-load
 DOC

--- a/README.md
+++ b/README.md
@@ -33,9 +33,49 @@ hab pkg install chef/chef-load
 hab pkg binlink chef/chef-load chef-load
 ```
 
-### Install onto AWS EC2 with Habitat
+### Install onto AWS EC2
+#### Requirements:
 
-Follow these steps to install onto EC2, the latest version of chef-load from the habitat depot in the `chef` origin:
+##### Install the AWS vagrant plugin
+```
+vagrant plugin install vagrant-aws
+```
+
+##### Import the vagrant AWS dummy box
+```
+vagrant box add aws https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box
+```
+
+##### ENV variables needed
+
+1. `GITHUB_TOKEN` env variable with private repo read access to `chef` org repos
+
+2. `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` of `Chef Engineering AWS` account.
+You can create them by reachable via Okta
+
+##### Load SSH private key identity
+
+Add to the ssh agent the private key that is allowed to clone the `a2` github repo:
+```
+ssh-add
+```
+
+##### Launch the A2 the instance
+
+The Vagrantfile creates the instance in the `us-east-2`(Ohio) region. You will need to specify the AWS SSH key to be used for the instance via env variable `AWS_SSH_KEY_NAME`.
+
+Start it up!
+```
+AWS_SSH_KEY_NAME=<your aws key name> vagrant up
+vagrant ssh
+```
+
+or as a one liner:
+```
+AWS_SSH_KEY_NAME='myawskey' vagrant up; vagrant ssh
+```
+
+Follow these steps to install onto your newly created EC2 instance, the latest version of chef-load from the habitat depot in the `chef` origin:
 
 1. From the root of chef-load, run: `vagrant up; vagrant ssh;`
 2. Install and link chef-load binary
@@ -44,7 +84,9 @@ hab pkg install chef/chef-load
 hab pkg binlink chef/chef-load chef-load
 ```
 
-### Generate a chef-load configuration file.  
+When you no longer need or want to pay for the instance, simply run `vagrant destroy`
+
+### Generate a chef-load configuration file.
 
 The configuration file uses [TOML syntax](https://github.com/toml-lang/toml) and documents a lot of the flexibility of chef-load so please read it.
 

--- a/README.md
+++ b/README.md
@@ -66,25 +66,18 @@ The Vagrantfile creates the instance in the `us-east-2`(Ohio) region. You will n
 
 Start it up!
 ```
-AWS_SSH_KEY_NAME=<your aws key name> vagrant up
-vagrant ssh
+AWS_SSH_KEY_NAME=<your-aws-key> vagrant up; vagrant ssh
 ```
 
-or as a one liner:
+If you wish to use an aws instance that's larger than the default t3.nano, simply set an ENV var named `CHEF_LOAD_AWS_INSTANCE_TYPE` before running vagrant commands
+
 ```
-AWS_SSH_KEY_NAME='myawskey' vagrant up; vagrant ssh
+CHEF_LOAD_AWS_INSTANCE_TYPE=t3.small AWS_SSH_KEY_NAME=<your-aws-key> vagrant up; vagrant ssh
 ```
 
-Follow these steps to install onto your newly created EC2 instance, the latest version of chef-load from the habitat depot in the `chef` origin:
 
-1. From the root of chef-load, run: `vagrant up; vagrant ssh;`
-2. Install and link chef-load binary
-```
-hab pkg install chef/chef-load
-hab pkg binlink chef/chef-load chef-load
-```
 
-When you no longer need or want to pay for the instance, simply run `vagrant destroy`
+When you no longer want the instance, simply run `vagrant destroy`
 
 ### Generate a chef-load configuration file.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,6 +122,9 @@ EOT
   hab studio enter
 EOF
 STUDIORC="#{home_dir}/chef-load/.studiorc"
+
+echo 'install_if_missing chef/chef-load \033[0m\n'>> $STDIORC
+
 echo 'printf "\033[0;31m>>> ONE MORE STEP NEEDED TO RUN chef-load <<<\033[0m\n"' >> $STUDIORC
 echo 'printf "1. Run this here:\033[1;32m hab pkg install --binlink chef/chef-load \033[0m\n"' >> $STUDIORC
 SCRIPT
@@ -140,9 +143,10 @@ Vagrant.configure('2') do |config|
     aws.access_key_id = "#{ENV['AWS_ACCESS_KEY_ID']}"
     aws.secret_access_key = "#{ENV['AWS_SECRET_ACCESS_KEY']}"
     aws.keypair_name = ENV['AWS_SSH_KEY_NAME']
+    aws.instance_type = ENV['CHEF_LOAD_AWS_INSTANCE_TYPE'] || 't3.micro'
     #aws.instance_type = 't3.nano'       # 1CPU, .5GB RAM
     #aws.instance_type = 't3.micro'      # 1CPU, 1GB RAM
-    aws.instance_type = 't3.small'      # 1CPU, 2GB RAM
+    #aws.instance_type = 't3.small'      # 1CPU, 2GB RAM
     #aws.instance_type = 'm5.large'      # 2CPU, 8GB RAM
     #aws.instance_type = 'm5.xlarge'   # 4CPU, 16GB RAM
     # aws.instance_type = 'm5.2xlarge'  # 8CPU, 32GB RAM

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -123,10 +123,10 @@ EOT
 EOF
 STUDIORC="#{home_dir}/chef-load/.studiorc"
 
-echo 'hab pkg install chef/chef-load \n'>> $STUDIORC
+echo 'install_if_missing chef/chef-load chef-load' >>  $STUDIORC
 
-echo 'printf "\033[0;31m>>> ONE MORE STEP NEEDED TO RUN chef-load <<<\033[0m\n"' >> $STUDIORC
-echo 'printf "1. Run this here:\033[1;32m hab pkg install --binlink chef/chef-load \033[0m\n"' >> $STUDIORC
+echo 'printf "\033[0;31m>>> Next steps <<<\033[0m\n"' >> $STUDIORC
+echo 'printf "View Readme file to learn how to run chef-load commands\033[1;32m  \033[0m\n\n"' >> $STUDIORC
 SCRIPT
 
 if ENV['AWS_SSH_KEY_PATH'].nil?

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -123,7 +123,7 @@ EOT
 EOF
 STUDIORC="#{home_dir}/chef-load/.studiorc"
 
-echo 'install_if_missing chef/chef-load \033[0m\n'>> $STDIORC
+echo 'hab pkg install chef/chef-load \n'>> $STUDIORC
 
 echo 'printf "\033[0;31m>>> ONE MORE STEP NEEDED TO RUN chef-load <<<\033[0m\n"' >> $STUDIORC
 echo 'printf "1. Run this here:\033[1;32m hab pkg install --binlink chef/chef-load \033[0m\n"' >> $STUDIORC

--- a/chef-load-local.toml
+++ b/chef-load-local.toml
@@ -1,0 +1,192 @@
+# log_file specifies the location to log API requests
+log_file = "/home/rickm/log/chef-load/chef-load.log"
+
+# The chef_server_url, client_name and client_key parameters must be set if you want
+# to make API requests to a Chef Server.
+#
+# chef-load will also automatically attempt to connect to the Chef Server authenticated data collector proxy.
+# If you enabled this feature on the Chef Server, Chef Client run data will automatically be forwarded to Automate.
+# If you do not have Automate or the feature is disabled on the Chef Server, chef-load will detect this and
+# disable data collection.
+#
+# Be sure to include the organization name
+# For example: chef_server_url = "https://chef.example.com/organizations/demo/"
+# chef_server_url = ""
+#
+# The client defined by client_name needs to be an admin user of the Chef Server org.
+# client_name = "CLIENT_NAME"
+# client_key = "/path/to/CLIENT_NAME.pem"
+
+# The data_collector_url must be set if you want to make API requests directly to an Automate server.
+# For example: data_collector_url = "https://automate.example.org/data-collector/v0/"
+data_collector_url = "https://a2-dev.test/data-collector/v0/"
+
+# The Authorization token for the Automate server.
+# The following default value is sufficient unless you set your own token in your Automate server.
+data_collector_token = "S0RmW0bSt-T9nJVAwp__lozuw4Y="
+# Ohai data will be loaded from this file and used for the nodes' automatic attributes.
+# See the chef-load README for instructions for creating an ohai JSON file.
+# ohai_json_file = "/path/to/example-ohai.json"
+
+# Data from a converge status report will be loaded from this file and used
+# for each node's converge status report that is sent to the Automate server.
+# See the chef-load README for instructions for creating a converge status JSON file.
+converge_status_json_file = "/home/rickm/workspace/go/src/github.com/chef/chef-load/sample-data/example-converge-status.json"
+
+# Data from a compliance status report will be loaded from this file and used
+# for each node's compliance status report that is sent to the Automate server.
+# See the chef-load README for instructions for creating a compliance status JSON file.
+compliance_status_json_file = "/home/rickm/workspace/go/src/github.com/chef/chef-load/sample-data/example-compliance-status.json"
+
+# Directory where compliance sample inspec reports live.  Compliance load requires these sample reports
+# Use these as templates for creating the loaded reports for the generate action.
+# See the chef-load README for instructions for obtaining the samples.
+compliance_sample_reports_dir = "/home/rickm/workspace/go/src/github.com/chef/chef-load/sample-data/inspec-reports"
+
+# chef-load will evenly distribute the number of nodes across the desired interval (minutes)
+# Examples:
+#   30 nodes / 30 minute interval =  1 chef-client run per minute
+# 1800 nodes / 30 minute interval = 60 chef-client runs per minute
+num_nodes = 1800
+interval = 30
+
+# During the same interval of time, it is also possible to load a number of Chef actions
+num_actions = 10
+
+# This prefix will go at the beginning of each node name.
+# This enables running multiple instances of chef-load without affecting each others' nodes
+# For example, a value of "chef-load" will result in nodes named "chef-load-1", "chef-load-2", ...
+node_name_prefix = "chef-load-1"
+
+# Chef environment used for each node
+# chef_environment = "_default"
+
+# run_list is the run list used for each node. It should be a list of strings.
+# For example: run_list = [ "role[role_name]", "recipe_name", "recipe[different_recipe_name@1.0.0]" ]
+# The default value is an empty run_list.
+# run_list = [ ]
+
+# sleep_duration is an optional setting that is available to provide a delay to simulate
+# the amount of time a Chef Client takes actually converging all of the run list's resources.
+# sleep_duration is measured in seconds
+# sleep_duration = 0
+
+# days_back is an optional setting that allows the load of historical data. When provided, the tool
+# will use this value to load the data from today to the provided day back.
+days_back = 2
+
+# download_cookbooks controls which chef-client run downloads cookbook files.
+# Options are: "never", "first" (first chef-client run only), "always"
+#
+# Downloading cookbooks can significantly increase the number of API requests that chef-load
+# makes depending on the run_list. If you aren't concerned with simulating the download of cookbook files
+# then the recommendation is to use "never" or "first".
+#
+# download_cookbooks = "never"
+
+# api_get_requests is an optional list of API GET requests that are made during the chef-client run.
+# This is used to simulate the API requests that the cookbooks would make.
+# For example, it can make Chef Search or data bag item requests.
+# The values can be either full URLs that include the chef_server_url portion or just the portion of
+# the URL that comes after the chef_server_url.
+# For example, to make a Chef Search API request that searches for all nodes you can use either of the
+# following values:
+#
+# "https://chef.example.com/organizations/orgname/search/node?q=*%253A*&sort=X_CHEF_id_CHEF_X%20asc&start=0"
+# or
+# "search/node?q=*%253A*&sort=X_CHEF_id_CHEF_X%20asc&start=0"
+#
+# api_get_requests = [ ]
+
+# chef_version sets the value of the X-Chef-Version HTTP header in API requests sent to the Chef Server.
+# This value represents the version of the Chef Client making the API requests. The default is "13.2.20"
+# chef_version = "13.2.20"
+
+# Ever since Chef Client 12.x was released the default behavior has been for the Chef Client to create its
+# own client key locally and then upload the public side to the Chef Server when it creates the client object.
+# chef-load simulates this behavior. However, if you want chef-load to ask the Chef Server to create a client key
+# when the client object is created then set chef_server_creates_client_key to true.
+# chef_server_creates_client_key = false
+
+# Send data to the Chef server's Reporting service
+# enable_reporting = false
+
+# Generate Random Data
+# random_data = true
+
+# Generate Liveness Agent Data
+# liveness_agent = true
+
+
+# Matrix settings for Compliance Generation.  This is to ensure a diversity of nodes/scan/profiles
+# for compliance data. This only applied when running in "this day back" or "generate" mode.
+# In the future, it would be great if we could harmonize this with the converge nodes so that
+# we will have consistancy between that which is ingested between the two
+[matrix]
+  [matrix.samples]
+    [[matrix.samples.platforms]]
+    name = "c5-with-skip-message-depends"
+    target = "ssh://root@0.0.0.0:11032"
+    profiles = [
+      "mylinux-success-1.8.9",
+      "myrapper-child-0.6.2"
+    ]
+
+    [[matrix.samples.platforms]]
+    name = "c5-with-skip-message"
+    target = "ssh://root@0.0.0.0:11032"
+    profiles = [
+      "mylinux-success-1.8.9",
+      "myprofile1-1.0.0"
+    ]
+
+    [[matrix.samples.platforms]]
+    name = "c5"
+    target = "ssh://root@0.0.0.0:11032"
+    profiles = [
+      "mylinux-success-1.8.9"
+    ]
+
+  [matrix.simulation]
+  days = 10 
+  nodes = 40000
+  max_scans = 2 
+  total_max_scans = 1000000
+  format = "full"
+
+  [matrix.statistics]
+    [[matrix.statistics.sets]]
+    nodes = 10
+    scan_per_day = 1
+
+    [[matrix.statistics.sets]]
+    nodes = 10
+    scan_per_day = 24
+
+    [[matrix.statistics.sets]]
+    nodes = 100
+    scan_per_day = 1
+
+    [[matrix.statistics.sets]]
+    nodes = 100
+    scan_per_day = 24
+
+    [[matrix.statistics.sets]]
+    nodes = 1000
+    scan_per_day = 1
+
+    [[matrix.statistics.sets]]
+    nodes = 1000
+    scan_per_day = 24
+
+    [[matrix.statistics.sets]]
+    nodes = 10000
+    scan_per_day = 1
+
+    [[matrix.statistics.sets]]
+    nodes = 10000
+    scan_per_day = 24
+
+    [[matrix.statistics.sets]]
+    nodes = 10000
+    scan_per_day = 96

--- a/lib/config.go
+++ b/lib/config.go
@@ -135,7 +135,7 @@ func Default() Config {
 						"apache-baseline-2.0.2", "mysql-baseline-2.1.0"}},
 					{Name: "u12", Profiles: []string{"cis-ubuntu12_04lts-level1-1.1.0-2"}},
 					{Name: "u14", Profiles: []string{"mylinux-success-1.8.9"}},
-					{Name: "u18", Profiles: []string{"linux-baseline-2.2.0", "ssh-baseline-2.2.0"}},
+					{Name: "u18", Profiles: []string{"linux-baseline-2.2.0", "ssh-baseline1-2.2.0"}},
 				},
 			},
 			Statistics: Statistics{

--- a/lib/config.go
+++ b/lib/config.go
@@ -123,6 +123,8 @@ func Default() Config {
 			},
 			Samples: Samples{
 				Platforms: []Platform{
+					{Name: "c5-with-skip-message-depends", Profiles: []string{"mylinux-success-1.8.9","myrapper-child-0.6.2"}},
+					{Name: "c5-with-skip-message", Profiles: []string{"mylinux-success-1.8.9","myprofile1-1.0.0"}},
 					{Name: "c5", Profiles: []string{"mylinux-success-1.8.9"}},
 					{Name: "c6", Profiles: []string{"cis-centos6-level1-1.1.0-1.4", "ssh-baseline-2.2.0"}},
 					{Name: "c7", Profiles: []string{"mylinux-success-1.8.9"}},

--- a/sample-data/inspec-reports/c5-with-skip-message-depends-full.json
+++ b/sample-data/inspec-reports/c5-with-skip-message-depends-full.json
@@ -1,0 +1,153 @@
+{
+  "platform": {
+    "name": "centos",
+    "release": "5.11"
+  },
+  "profiles": [
+    {
+      "name": "myrapper-child",
+      "version": "0.6.2",
+      "sha256": "7c23eca1ca68dd0bb34a04f6c24a2a77642d260c713c167dbf1a9cdb5c0d00b0",
+      "title": "Linux Wrapper Child Profile",
+      "maintainer": "Demo, Inc.",
+      "summary": "Profile that wraps other profiles",
+      "license": "Apache-2.0",
+      "copyright": "Demo, Inc.",
+      "copyright_email": "support@example.com",
+      "supports": [],
+      "attributes": [],
+      "depends": [
+        {
+          "name": "myprofile1-new-name",
+          "path": "../myprofile1",
+          "status": "skipped",
+          "skip_message": "Skipping profile: 'myprofile1' on unsupported platform: 'centos/5.11'."
+        }
+      ],
+      "groups": [
+        {
+          "id": "controls/defaut.rb",
+          "controls": [
+            "one"
+          ]
+        }
+      ],
+      "controls": [
+        {
+          "id": "one",
+          "title": "control number one",
+          "desc": "description of control #1",
+          "descriptions": [
+            {
+              "label": "default",
+              "data": "description of control #1"
+            }
+          ],
+          "impact": 0.5,
+          "refs": [],
+          "tags": {},
+          "code": "control 'one' do\n  title 'control number one'\n  desc 'description of control #1'\n  describe 2 do\n    it { should eq 2 }\n  end\nend\n",
+          "source_location": {
+            "line": 3,
+            "ref": "../myrapper-child/controls/defaut.rb"
+          },
+          "results": [
+            {
+              "status": "passed",
+              "code_desc": "2 should eq 2",
+              "run_time": 0.002067,
+              "start_time": "2018-10-19T16:48:48+01:00"
+            }
+          ]
+        }
+      ],
+      "status": "loaded"
+    },
+    {
+      "name": "mylinux-success",
+      "version": "1.8.9",
+      "sha256": "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27",
+      "title": "My Demo Linux successful profile",
+      "maintainer": "Chef Software, Inc.",
+      "summary": "Demonstrates the use of InSpec Compliance Profile",
+      "license": "Apache 2 license",
+      "copyright": "Chef Software, Inc.",
+      "copyright_email": "support@chef.io",
+      "supports": [
+
+      ],
+      "attributes": [
+
+      ],
+      "groups": [
+        {
+          "id": "controls/success.rb",
+          "controls": [
+            "/etc/passwd must exist",
+            "/etc/group must exist"
+          ]
+        }
+      ],
+      "controls": [
+        {
+          "id": "/etc/passwd must exist",
+          "title": "Checking for /etc/passwd",
+          "desc": "Checking for /etc/passwd desc",
+          "impact": 0.6,
+          "refs": [
+
+          ],
+          "tags": {
+          },
+          "code": "control '/etc/passwd must exist' do\n  title 'Checking for /etc/passwd'\n  desc 'Checking for /etc/passwd desc'\n  impact 0.6\n  describe file('/etc/passwd') do\n    it { should be_file }\n  end\nend\n",
+          "source_location": {
+            "line": 2,
+            "ref": "controls/success.rb"
+          },
+          "results": [
+            {
+              "status": "passed",
+              "code_desc": "File /etc/passwd should be file",
+              "run_time": 0.045614,
+              "start_time": "2018-06-27T15:02:12+01:00"
+            }
+          ]
+        },
+        {
+          "id": "/etc/group must exist",
+          "title": "Checking for /etc/group",
+          "desc": "Checking for /etc/group desc",
+          "impact": 0.3,
+          "refs": [
+
+          ],
+          "tags": {
+          },
+          "code": "control '/etc/group must exist' do\n  title 'Checking for /etc/group'\n  desc 'Checking for /etc/group desc'\n  impact 0.3\n  describe file('/etc/group') do\n    it { should be_file }\n  end\nend\n",
+          "source_location": {
+            "line": 11,
+            "ref": "controls/success.rb"
+          },
+          "results": [
+            {
+              "status": "passed",
+              "code_desc": "File /etc/group should be file",
+              "run_time": 0.049345,
+              "start_time": "2018-06-27T15:02:13+01:00"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "statistics": {
+    "duration": 0.095788
+  },
+  "version": "2.2.20",
+  "node_name": "to_be_generated",
+  "node_uuid": "to_be_generated",
+  "report_uuid": "to_be_generated",
+  "end_time": "to_be_generated",
+  "environment": "to_be_generated",
+  "type": "inspec_report"
+}

--- a/sample-data/inspec-reports/c5-with-skip-message-full.json
+++ b/sample-data/inspec-reports/c5-with-skip-message-full.json
@@ -1,0 +1,115 @@
+{
+  "platform": {
+    "name": "centos",
+    "release": "5.11"
+  },
+  "profiles": [
+    {
+      "name": "myprofile1",
+      "version": "1.0.0",
+      "sha256": "5596bb07ef4f11fd2e03a0a80c4adb7c61fc0b4d0aa6c1410b3c715c94b367da",
+      "title": "My Profile 1 title",
+      "maintainer": "Demo, Inc.",
+      "summary": "My Profile 1 summary",
+      "license": "Apache-2.0",
+      "copyright": "Demo, Inc.",
+      "copyright_email": "support@example.com",
+      "supports": [
+        {
+          "platform-family": "windows"
+        }
+      ],
+      "attributes": [],
+      "groups": [],
+      "controls": [],
+      "status": "skipped",
+      "skip_message": "Skipping profile: 'myprofile1' on unsupported platform: 'centos/5.11'."
+    },
+    {
+      "name": "mylinux-success",
+      "version": "1.8.9",
+      "sha256": "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27",
+      "title": "My Demo Linux successful profile",
+      "maintainer": "Chef Software, Inc.",
+      "summary": "Demonstrates the use of InSpec Compliance Profile",
+      "license": "Apache 2 license",
+      "copyright": "Chef Software, Inc.",
+      "copyright_email": "support@chef.io",
+      "supports": [
+
+      ],
+      "attributes": [
+
+      ],
+      "groups": [
+        {
+          "id": "controls/success.rb",
+          "controls": [
+            "/etc/passwd must exist",
+            "/etc/group must exist"
+          ]
+        }
+      ],
+      "controls": [
+        {
+          "id": "/etc/passwd must exist",
+          "title": "Checking for /etc/passwd",
+          "desc": "Checking for /etc/passwd desc",
+          "impact": 0.6,
+          "refs": [
+
+          ],
+          "tags": {
+          },
+          "code": "control '/etc/passwd must exist' do\n  title 'Checking for /etc/passwd'\n  desc 'Checking for /etc/passwd desc'\n  impact 0.6\n  describe file('/etc/passwd') do\n    it { should be_file }\n  end\nend\n",
+          "source_location": {
+            "line": 2,
+            "ref": "controls/success.rb"
+          },
+          "results": [
+            {
+              "status": "passed",
+              "code_desc": "File /etc/passwd should be file",
+              "run_time": 0.045614,
+              "start_time": "2018-06-27T15:02:12+01:00"
+            }
+          ]
+        },
+        {
+          "id": "/etc/group must exist",
+          "title": "Checking for /etc/group",
+          "desc": "Checking for /etc/group desc",
+          "impact": 0.3,
+          "refs": [
+
+          ],
+          "tags": {
+          },
+          "code": "control '/etc/group must exist' do\n  title 'Checking for /etc/group'\n  desc 'Checking for /etc/group desc'\n  impact 0.3\n  describe file('/etc/group') do\n    it { should be_file }\n  end\nend\n",
+          "source_location": {
+            "line": 11,
+            "ref": "controls/success.rb"
+          },
+          "results": [
+            {
+              "status": "passed",
+              "code_desc": "File /etc/group should be file",
+              "run_time": 0.049345,
+              "start_time": "2018-06-27T15:02:13+01:00"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "statistics": {
+    "duration": 0.095788
+  },
+  "version": "2.2.20",
+  "node_name": "to_be_generated",
+  "node_uuid": "to_be_generated",
+  "report_uuid": "to_be_generated",
+  "end_time": "to_be_generated",
+  "environment": "to_be_generated",
+  "type": "inspec_report"
+}


### PR DESCRIPTION
As a user of chef-load who wants to run chef-load in ec2 and load data into an automate instance that is remote, we need documentation to serve as a guide.  This change starts that documentation which will continue to grow