### PR TITLE
Whitespace commit to trigger hab build w/ refreshed dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# chef-load Change Log
+# chef-load Change Log 
 
 ## 3.0.0 (2017-08-31)
 


### PR DESCRIPTION
Signed-off-by: Josh Hudson <jhudson@chef.io>

This contains a simple whitespace change in the README to trigger a rebuild of the chef-load habitat package, as it's glibc dependency conflicts with most core plans since the last core plan refresh.

```
   chef/chef-load/4.0.0/20190115234841
        core/glibc/2.27/20180608041157 (*)
            core/linux-headers/4.15.9/20180608041107 (*)
```
