### PR TITLE
Spaces in environment names cause 400's in Chef Infra Server

### DIFF
--- a/lib/random_data.go
+++ b/lib/random_data.go
@@ -56,13 +56,13 @@ var (
 		"mountain",
 		"swamp",
 		"underdark",
-		"astral plane",
-		"ethereal plane",
-		"plane of shadow",
+		"astral-plane",
+		"ethereal-plane",
+		"plane-of-shadow",
 		"feywild",
 		"shadowfell",
-		"mirror plane",
-		"outer space",
+		"mirror-plane",
+		"outer-space",
 		"acceptance-org-proj-master",
 	}
 


### PR DESCRIPTION
Changing the spaces to hyphens.
