### PR TITLE
Fix config file generation call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ hab pkg binlink chef/chef-load chef-load
 The configuration file uses [TOML syntax](https://github.com/toml-lang/toml) and documents a lot of the flexibility of chef-load so please read it.
 
 ```
-chef-load init > chef-load.toml
+chef-load -sample-config > chef-load.toml
 ```
 
 chef-load logs all API requests in the file specified by the `log_file` setting in the config file. The default value is `/var/log/chef-load/chef-load.log`.


### PR DESCRIPTION
## Description
If you run `chef-load init > chef-load.toml` (as the `README.md` dictates) you end up with a `chef-load.toml` file that looks like this:

```
Usage of chef-load:
```

AFAICT, this is just a typo and one should really be using the `-sample-config` flag.
```

## Related Issue
Not necessary.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ This document doesn't actually exist ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
