### PR TITLE
adds cookbooksData for population on generated content

### DIFF
--- a/lib/chef_client_run.go
+++ b/lib/chef_client_run.go
@@ -64,6 +64,7 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 			policyGroup: "hello_policy_group",
 			policyName:  "hello_policy_name",
 			chefTags:    []string{"tag1", "tag2", "tag3"},
+			cookbooks:   cookbooksData,
 		}
 	)
 

--- a/lib/compliance_generator.go
+++ b/lib/compliance_generator.go
@@ -34,6 +34,7 @@ type NodeDetails struct {
 	policyGroup string
 	orgName     string
 	chefTags    []string
+	cookbooks   map[string]interface{}
 }
 
 func GenerateComplianceData(config *Config, requests chan *request) error {
@@ -148,6 +149,7 @@ func generateNodes(nodeNamePrefix string, platforms []Platform, nodesCount int) 
 			policyGroup: generatePolicyGroup(),
 			policyName:  generatePolicyName(),
 			platform:    platforms[rand.Intn(len(platforms))].Name,
+			cookbooks:   cookbooksData,
 		}
 		node.fqdn = node.name
 		node.nodeUUID = uuid.NewMD5(uuid.NameSpaceDNS, []byte(node.name))

--- a/lib/generator.go
+++ b/lib/generator.go
@@ -381,7 +381,7 @@ func randomChefClientRun(config *Config, chefClient chef.Client, nodeName string
 	//"platform_family": "rhel",
 
 	node.AutomaticAttributes["recipes"] = randRecipes
-	node.AutomaticAttributes["cookbooks"] = map[string]interface{}{}
+	node.AutomaticAttributes["cookbooks"] = cookbooksData
 	node.AutomaticAttributes["uptime_seconds"] = 0
 	node.NormalAttributes = genRandomAttributes()
 	node.NormalAttributes["tags"] = genRandomTags()

--- a/lib/random_data.go
+++ b/lib/random_data.go
@@ -47,6 +47,16 @@ var (
 		"Dot.Comma,Big;\"Trouble",
 	}
 
+	cookbooksData = map[string]interface{}{
+		"chef-client":     map[string]interface{}{"version": "8.1.1"},
+		"cron":            map[string]interface{}{"version": "4.1.1"},
+		"compat_resource": map[string]interface{}{"version": "12.19.0"},
+		"logrotate":       map[string]interface{}{"version": "2.1.0"},
+		"windows":         map[string]interface{}{"version": "3.0.5"},
+		"ohai":            map[string]interface{}{"version": "5.1.0"},
+		"audit":           map[string]interface{}{"version": "4.0.0"},
+	}
+
 	environments = []string{
 		"arctic",
 		"coast",


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Adds `cookbooksData` to random data content and sets this data to be populated during generated CCRs and compliance runs.  Currently `node['cookbooks']` is not being populated by `chef-load` and this prevents testing of `chef report cookbooks` accurately.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

![image](https://user-images.githubusercontent.com/8185808/119717924-8ee2d180-be2c-11eb-8535-493412bc430e.png)
