### PR TITLE
New features to fine-tune client run controls

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -64,6 +64,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("random_data", "r", false, "Generates random data")
 	rootCmd.PersistentFlags().BoolP("liveness_agent", "l", false, "Generates liveness agent data")
 	rootCmd.PersistentFlags().IntP("interval", "i", 30, "Interval between a node's chef-client runs, in minutes")
+	// TODO unless these apply globally (they don't yet) they should be added to the "start" command.
+	rootCmd.PersistentFlags().Float64P("download_cookbooks_scale_factor", "C", 1.0, "What probability (0.0 - 1.0) that any given cookbook will need to be downloaded")
+	rootCmd.PersistentFlags().BoolP("skip_client_creation", "S", false, "Skips creation of client during each node's initial chef-client run")
+	rootCmd.PersistentFlags().Float64P("node_replacement_rate", "R", 0.0, "How frequently (0.0 - 1.0) are new nodes generated and old ones no longer run. Default 0.0")
 	viper.BindPFlags(rootCmd.PersistentFlags())
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -55,64 +55,74 @@ type Matrix struct {
 }
 
 type Config struct {
-	RunChefClient              bool
-	LogFile                    string   `mapstructure:"log_file"`
-	ChefServerURL              string   `mapstructure:"chef_server_url"`
-	ClientName                 string   `mapstructure:"client_name"`
-	ClientKey                  string   `mapstructure:"client_key"`
-	DataCollectorURL           string   `mapstructure:"data_collector_url"`
-	DataCollectorToken         string   `mapstructure:"data_collector_token"`
-	OhaiJSONFile               string   `mapstructure:"ohai_json_file"`
-	ConvergeStatusJSONFile     string   `mapstructure:"converge_status_json_file"`
-	ComplianceStatusJSONFile   string   `mapstructure:"compliance_status_json_file"`
-	ComplianceSampleReportsDir string   `mapstructure:"compliance_sample_reports_dir"`
-	NumActions                 int      `mapstructure:"num_actions"`
-	NumNodes                   int      `mapstructure:"num_nodes"`
-	Interval                   int      `mapstructure:"interval"`
-	NodeNamePrefix             string   `mapstructure:"node_name_prefix"`
-	ChefEnvironment            string   `mapstructure:"chef_environment"`
-	RunList                    []string `mapstructure:"run_list"`
-	SleepDuration              int      `mapstructure:"sleep_duration"`
-	DownloadCookbooks          string   `mapstructure:"download_cookbooks"`
-	APIGetRequests             []string `mapstructure:"api_get_requests"`
-	ChefVersion                string   `mapstructure:"chef_version"`
-	ChefServerCreatesClientKey bool     `mapstructure:"chef_server_creates_client_key"`
-	RandomData                 bool     `mapstructure:"random_data"`
-	LivenessAgent              bool     `mapstructure:"liveness_agent"`
-	EnableReporting            bool     `mapstructure:"enable_reporting"`
-	DaysBack                   int      `mapstructure:"days_back"`
-	Threads                    int      `mapstructure:"threads"`
-	SleepTimeOnFailure         int      `mapstructure:"sleep_time_on_failure"`
-	Matrix                     *Matrix  `mapstructure:"matrix"`
+	RunChefClient                bool
+	LogFile                      string     `mapstructure:"log_file"`
+	ChefServerURL                string     `mapstructure:"chef_server_url"`
+	ClientName                   string     `mapstructure:"client_name"`
+	ClientKey                    string     `mapstructure:"client_key"`
+	DataCollectorURL             string     `mapstructure:"data_collector_url"`
+	DataCollectorToken           string     `mapstructure:"data_collector_token"`
+	OhaiJSONFile                 string     `mapstructure:"ohai_json_file"`
+	ConvergeStatusJSONFile       string     `mapstructure:"converge_status_json_file"`
+	ComplianceStatusJSONFile     string     `mapstructure:"compliance_status_json_file"`
+	ComplianceSampleReportsDir   string     `mapstructure:"compliance_sample_reports_dir"`
+	NumActions                   int        `mapstructure:"num_actions"`
+	NumNodes                     int        `mapstructure:"num_nodes"`
+	Interval                     int        `mapstructure:"interval"`
+	NodeNamePrefix               string     `mapstructure:"node_name_prefix"`
+	ChefEnvironment              string     `mapstructure:"chef_environment"`
+	RunList                      []string   `mapstructure:"run_list"`
+	RunLists                     [][]string `mapstructure:"run_lists"`
+	SleepDuration                int        `mapstructure:"sleep_duration"`
+	DownloadCookbooks            string     `mapstructure:"download_cookbooks"`
+	DownloadCookbooksScaleFactor float64    `mapstructure:"download_cookbooks_scale_factor"`
+	APIGetRequests               []string   `mapstructure:"api_get_requests"`
+	ChefVersion                  string     `mapstructure:"chef_version"`
+	ChefServerCreatesClientKey   bool       `mapstructure:"chef_server_creates_client_key"`
+	NodeSaveFrequency            float64    `mapstructure:"node_save_frequency"`
+	RandomData                   bool       `mapstructure:"random_data"`
+	LivenessAgent                bool       `mapstructure:"liveness_agent"`
+	EnableReporting              bool       `mapstructure:"enable_reporting"`
+	DaysBack                     int        `mapstructure:"days_back"`
+	Threads                      int        `mapstructure:"threads"`
+	SleepTimeOnFailure           int        `mapstructure:"sleep_time_on_failure"`
+	Matrix                       *Matrix    `mapstructure:"matrix"`
+	SkipClientCreation           bool       `mapstructure:"skip_client_creation"`
+	NodeReplacementRate          float64    `mapstructure:"node_replacement_rate"`
 }
 
 func Default() Config {
 	return Config{
-		RunChefClient:              false,
-		LogFile:                    "/var/log/chef-load/chef-load.log",
-		ChefServerURL:              "",
-		DataCollectorURL:           "",
-		DataCollectorToken:         "93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506",
-		OhaiJSONFile:               "",
-		ConvergeStatusJSONFile:     "",
-		ComplianceStatusJSONFile:   "",
-		ComplianceSampleReportsDir: "",
-		NumNodes:                   30,
-		Interval:                   30,
-		NodeNamePrefix:             "chef-load",
-		ChefEnvironment:            "_default",
-		RunList:                    make([]string, 0),
-		SleepDuration:              0,
-		DownloadCookbooks:          "never",
-		ChefVersion:                "13.2.20",
-		ChefServerCreatesClientKey: false,
-		EnableReporting:            false,
-		RandomData:                 false,
-		LivenessAgent:              false,
-		NumActions:                 30,
-		DaysBack:                   0,
-		Threads:                    3000,
-		SleepTimeOnFailure:         5,
+		RunChefClient:                false,
+		LogFile:                      "/var/log/chef-load/chef-load.log",
+		ChefServerURL:                "",
+		DataCollectorURL:             "",
+		DataCollectorToken:           "93a49a4f2482c64126f7b6015e6b0f30284287ee4054ff8807fb63d9cbd1c506",
+		OhaiJSONFile:                 "",
+		ConvergeStatusJSONFile:       "",
+		ComplianceStatusJSONFile:     "",
+		ComplianceSampleReportsDir:   "",
+		NumNodes:                     30,
+		Interval:                     30,
+		NodeNamePrefix:               "chef-load",
+		ChefEnvironment:              "_default",
+		RunList:                      make([]string, 0),
+		RunLists:                     make([][]string, 0),
+		SleepDuration:                0,
+		DownloadCookbooks:            "never",
+		DownloadCookbooksScaleFactor: 1.0,
+		ChefVersion:                  "13.2.20",
+		NodeSaveFrequency:            1.0,
+		ChefServerCreatesClientKey:   false,
+		EnableReporting:              false,
+		RandomData:                   false,
+		LivenessAgent:                false,
+		NumActions:                   30,
+		DaysBack:                     0,
+		Threads:                      3000,
+		SleepTimeOnFailure:           5,
+		SkipClientCreation:           false,
+		NodeReplacementRate:          0.0,
 		Matrix: &Matrix{
 			Simulation: Simulation{
 				Days:          1,
@@ -201,7 +211,8 @@ func PrintSampleConfig() {
 # num_nodes = 30
 # interval = 30
 
-# During the same interval of time, it is also possible to load a number of Chef actions
+# During the same interval of time, generate and submit this number of Chef actions
+# Ignored if data_collector_url is not set.
 # num_actions = 30
 
 # This prefix will go at the beginning of each node name.
@@ -217,6 +228,15 @@ func PrintSampleConfig() {
 # The default value is an empty run_list.
 # run_list = [ ]
 
+# Alternatively, you can provide several run lists which will be chosen randomly on each run.
+# TODO future - allow weighting to determine frequency of each run list
+# If this value is provided, run_list is ignored.
+# This is an array of an array of strings. For example:
+# run_lists = [ [ "role[role_name]", "recipe_name"],  [ "role[role_name_1]", "role[role_name_2] " ] ]
+# The default value is empty
+
+# run_lists = [ ]
+
 # sleep_duration is an optional setting that is available to provide a delay to simulate
 # the amount of time a Chef Client takes actually converging all of the run list's resources.
 # sleep_duration is measured in seconds
@@ -227,13 +247,22 @@ func PrintSampleConfig() {
 # days_back = 30
 
 # download_cookbooks controls which chef-client run downloads cookbook files.
-# Options are: "never", "first" (first chef-client run only), "always"
+# Options are: "never", "first" (first chef-client run only), "always""
 #
 # Downloading cookbooks can significantly increase the number of API requests that chef-load
 # makes depending on the run_list. If you aren't concerned with simulating the download of cookbook files
 # then the recommendation is to use "never" or "first".
 #
 # download_cookbooks = "never"
+
+
+# What percent of required cookbooks will be downloaded on each run
+# For example if there are 10 cookbooks in the run list and scale factor is 0.1,
+# on average one cookbook will be downloaded per run. If download_cookbooks == "first",
+# then this is ignored and all cookbooks are downloaded.
+#
+# download_cookbooks_scale_factor = 1.0
+
 
 # api_get_requests is an optional list of API GET requests that are made during the chef-client run.
 # This is used to simulate the API requests that the cookbooks would make.
@@ -258,6 +287,21 @@ func PrintSampleConfig() {
 # chef-load simulates this behavior. However, if you want chef-load to ask the Chef Server to create a client key
 # when the client object is created then set chef_server_creates_client_key to true.
 # chef_server_creates_client_key = false
+
+# Specify how often to save nodes at the end of the chef client run.
+# 0.0 is never, 1.0 is always, and a number in between represents the percent of runs
+# which will save the node.
+# node_save_frequency = 1.0
+
+# When true, clients are not created for new nodes. If this is true, node_replacement_rate
+# is ignored.
+# skip_client_creation = false
+
+# Frequency with which old nodes are no longer used and new nodes (and clients)
+# are generated.  Value is probability with 0.0 being never, and 1.0
+# which will force every chef-client run to be from a new node/client.
+
+# node_replacement_rate = 0.0
 
 # Send data to the Chef server's Reporting service
 # enable_reporting = false

--- a/lib/generator.go
+++ b/lib/generator.go
@@ -38,6 +38,7 @@ func GenerateData(config *Config) error {
 	var (
 		numRequests = make(amountOfRequests)
 		requests    = make(chan *request)
+		startTime   = time.Now()
 	)
 
 	go func() {
@@ -76,7 +77,7 @@ func GenerateData(config *Config) error {
 
 	wg.Wait()
 
-	printAPIRequestProfile(numRequests)
+	printAPIRequestProfile(startTime, numRequests)
 
 	return nil
 }
@@ -440,12 +441,12 @@ func randomChefClientRun(config *Config, chefClient chef.Client, nodeName string
 	}
 
 	if config.RunChefClient {
-		// Calculate cookbook dependencies
 		ckbks := solveRunListDependencies(&chefClient, nodeName, config.ChefVersion, node.Environment, expandedRunList, requests)
 
-		// Download cookbooks
+		// This behaves differently than client run because we don't track a first run here.
+		// TODO - move the download_cookbooks_scale_factor to a) a better name, b) the 'run' command
 		if config.DownloadCookbooks == "always" || (config.DownloadCookbooks == "first") {
-			ckbks.download(&chefClient, nodeName, config.ChefVersion, requests)
+			ckbks.download(&chefClient, nodeName, config.ChefVersion, config.DownloadCookbooksScaleFactor, requests)
 		}
 	} else {
 		expandedRunList = runList.toStringSlice()

--- a/lib/run_list.go
+++ b/lib/run_list.go
@@ -96,6 +96,14 @@ func solveRunListDependencies(nodeClient *chef.Client, nodeName, chefVersion, ch
 	return ckbks
 }
 
+func parseRunLists(unparsedRunLists [][]string) []runList {
+	var rls []runList
+	for _, item := range unparsedRunLists {
+		rls = append(rls, parseRunList(item))
+	}
+	return rls
+}
+
 func parseRunList(unparsedRunList []string) runList {
 	var qualifiedRecipeRegExp = regexp.MustCompile(`^recipe\[([^\]@]+)(@([0-9]+(\.[0-9]+){1,2}))?\]$`)
 	var qualifiedRoleRegExp = regexp.MustCompile(`^role\[([^\]]+)\]$`)


### PR DESCRIPTION
In order to support tuning chef-load's simulated chef-client runs
to more closely match real-world scenarios, this
adds the following configuration changes. Most also
have corresponding CLI flags:

- run_lists allows you to specify an array of run lists
  one of which is chosen randomly for each client run.  This is
  because in large systems, the run-lists used is seldom
  uniform and repeated.  This allows us to rotate among multiple run
  lists, providing a more varied load pattern against related endpoints
  such as `cookbook_versions`.
- node_save_frequency  (0.0-1.0) - if < 1.0 default
  this randomizes whether or not a node save occurs, based on
  rand < node_save_frequency.  This was based on observations of
  high-traffic system in which a percentage of clients could be seen not
  saving the node (this can happen, for example, when override run lists
  are in use)
- download_cookbooks_scale_factor  0.0 - 1.0 -default 1 -  on average download
  this percent of cookbook files resolved in the expanded run
  list.  If download_cookbooks == 'first', scale factor is ignored and
  all cookbooks are downloaded. Default is 1.0 (100%)  for backward
  compatibilty.
  This was introduced because of the way chef-client behaves.
  Downloading cookbooks is rarely an all-or-nothing proposition. Files
  are downloaded and cached, so even when a cookbook changes we often
  weon't be downloading the whole thing - and we'll almost never
  download all cookbooks on each run of the client.
- skip_client_creation - when true, we will bypass client creation in
  simulated runs. Used to avoid extra ramp-up costs when re-using prefix
  in tests.
- node_replacement_rate  - 0.0 - 1.0, default 0, allows the operator to specify
  how frequently a node & client should be replaced with a new & client for the chef client run,
  allowing for traffic to include a steady rate stream of node/client creations after
  initial rampup

Some additional supporting changes:

- max concurrent CCRs are now throttled to the specified concurrency.
  Because a single node can't converge concurrently with itself,
  make sure chef-load `start` also doesn't do this by monitoring
  in-flight chef-runs and only starting a new run when there are fewer
  than node-count runs going.
  This also reduced busy-looping and reduced CPU usage of chef-load,
  making it possible to run several instances with relatively low
  resource usage.
- added rough calculation of total requests per second in the summary
report
- changes to the API summary:
  - include average number of API requests per second
  - group all requests to /roles/$ROLENAME together as /roles/ROLENAME.
    We may want to consider doing this for all API object requests as
    there is less value in seeing individual object names in this
    report.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>