### PR TITLE
changed README back to chef-load init for config gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ hab pkg binlink chef/chef-load chef-load
 The configuration file uses [TOML syntax](https://github.com/toml-lang/toml) and documents a lot of the flexibility of chef-load so please read it.
 
 ```
-chef-load -sample-config > chef-load.toml
+chef-load init > chef-load.toml
 ```
 
 chef-load logs all API requests in the file specified by the `log_file` setting in the config file. The default value is `/var/log/chef-load/chef-load.log`.


### PR DESCRIPTION
Signed-off-by: Rick Marry <rmarry@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
Back in April, this README was changed to instruct users to use:
`chef-load -sample-config > chef-load.toml` for config generation

This PR changes it back to the correct way which is:
`chef-load init > chef-load.toml`
 
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
