### PR TITLE
feat: add policyfile and compliance phase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ policy_name  = "base"
 policy_group = "production"
 ```
 
+To simulate a fleet spread across multiple policies within the same policy group, use the `policyfiles` list instead of `policy_name`. Each simulated chef-client run randomly picks one name from the list — all nodes share the same `policy_group`. This mirrors how `run_lists` works for legacy nodes. All listed policies must exist in the configured `policy_group` on the Chef Server.
+
+```toml
+load_mode    = "policyfile"
+policy_group = "production"
+policyfiles  = [ "base", "webserver", "database" ]
+```
+
+When `policyfiles` is non-empty, `policy_name` is ignored.
+
 For `"mixed"` mode, `policyfile_percentage` (default `0.5`) controls what fraction of simulated nodes use the policyfile API. Nodes are assigned deterministically by node number so the split is stable across runs.
 
 ```toml
@@ -81,6 +91,8 @@ policy_name           = "base"
 policy_group          = "production"
 policyfile_percentage = 0.3   # 30% policyfile, 70% legacy
 ```
+
+`policyfiles` works in `"mixed"` mode too — policyfile-assigned nodes will pick a policy name randomly from the list while legacy-assigned nodes continue to use `run_list`/`run_lists`.
 
 #### Compliance phase simulation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 ## Description
 
-chef-load is a tool that simulates Chef Client API load on a [Chef Server](https://www.chef.io/chef/) and/or a [Chef Automate server](https://www.chef.io/chef://www.chef.io/automate/).
+chef-load is a tool that simulates Chef Client API load on a [Chef Server](https://www.chef.io/chef/) and/or a [Chef Automate server](https://www.chef.io/automate/).
 
 It is designed to be easy to use yet powerfully flexible and accurate in its simulation of the chef-client run.
+
+It supports three load modes:
+
+* **`policyfile`** (default) — all nodes follow the policyfile API flow (`GET policy_groups/<group>/policies/<name>` / `GET cookbook_artifacts/<name>/<identifier>`), matching Chef Infra Client runs with `PolicyName`/`PolicyGroup` set.
+* **`legacy`** — all nodes follow the traditional run-list/roles/environments flow (original behaviour).
+* **`mixed`** — a configurable fraction of nodes use the policyfile flow; the remainder use the legacy flow.
 
 It works well at this point but there is always room for improvement so please provide feedback.
 
@@ -57,6 +63,36 @@ chef-load logs all API requests in the file specified by the `log_file` setting 
 Make sure `chef-load.toml` has appropriate settings for applying load to your Chef Server,
 Automate Server or both.
 
+#### Policyfile settings
+
+When `load_mode` is `"policyfile"` or `"mixed"`, set the target policy:
+
+```toml
+load_mode    = "policyfile"
+policy_name  = "base"
+policy_group = "production"
+```
+
+For `"mixed"` mode, `policyfile_percentage` (default `0.5`) controls what fraction of simulated nodes use the policyfile API. Nodes are assigned deterministically by node number so the split is stable across runs.
+
+```toml
+load_mode             = "mixed"
+policy_name           = "base"
+policy_group          = "production"
+policyfile_percentage = 0.3   # 30% policyfile, 70% legacy
+```
+
+#### Compliance phase simulation
+
+chef-load can simulate the built-in compliance phase introduced in Chef Infra Client 17+. When enabled, an `inspec_report` message is sent to the data collector at the end of each simulated chef-client run, linked to the run via `run_uuid` (matching actual chef-client behaviour).
+
+```toml
+enable_compliance_phase    = true
+compliance_phase_percentage = 1.0  # fraction of nodes that report compliance
+```
+
+If `compliance_status_json_file` is set, that file's content is used as the report body. Otherwise a minimal synthetic report is sent representing a node with no InSpec profiles configured.
+
 #### Chef API client
 
 The client defined by "client_name" in the chef-load configuration file needs to be an admin user of the Chef Server organization.
@@ -67,6 +103,25 @@ Run chef-load using only the configuration file.
 
 ```
 chef-load start --config chef-load.toml
+```
+
+You can override the load mode and policyfile settings on the command line:
+
+```
+# policyfile mode (default)
+chef-load start --config chef-load.toml --load_mode policyfile --policy_name base --policy_group production
+
+# legacy (run-list/roles/environments) mode
+chef-load start --config chef-load.toml --load_mode legacy
+
+# mixed mode — 40% policyfile, 60% legacy
+chef-load start --config chef-load.toml --load_mode mixed --policy_name base --policy_group production --policyfile_percentage 0.4
+```
+
+Enable compliance phase simulation:
+
+```
+chef-load start --config chef-load.toml --enable_compliance_phase --compliance_phase_percentage 0.5
 ```
 
 You can use the `--node_name_prefix` command line option to set the prefix for the node names. This
@@ -126,6 +181,16 @@ WantedBy=default.target
 ## API Request Profile
 
 chef-load prints an API request profile when it receives a `USR1` signal and when it is terminated.
+
+The URLs shown in the profile differ by load mode. In **policyfile** mode you will see requests like:
+
+```
+GET  /organizations/<org>/policy_groups/<group>/policies/<name>
+GET  /organizations/<org>/cookbook_artifacts/<name>/<identifier>
+POST /data-collector/v0/   (run_start, run_converge, and optionally inspec_report)
+```
+
+In **legacy** mode the profile looks like the example below (roles, environments, cookbook_versions).
 
 ```
 root@ip-172-31-17-147:~# ./chef-load start --config chef-load.toml --nodes 60 --interval 1 --node_name_prefix foo
@@ -209,7 +274,7 @@ chef-load's configuration file has the following settings to specify the path to
 
 * ohai_json_file
 * converge_status_json_file
-* compliance_status_json_file
+* compliance_status_json_file — also used as the body of `inspec_report` messages when `enable_compliance_phase = true`
 * compliance_sample_reports_dir
 
 The chef-load GitHub repo's ["sample-data" directory](https://github.com/jeremiahsnapp/chef-load/tree/master/sample-data) has a file for each type of data that can be used.

--- a/commands/root.go
+++ b/commands/root.go
@@ -68,6 +68,12 @@ func init() {
 	rootCmd.PersistentFlags().Float64P("download_cookbooks_scale_factor", "C", 1.0, "What probability (0.0 - 1.0) that any given cookbook will need to be downloaded")
 	rootCmd.PersistentFlags().BoolP("skip_client_creation", "S", false, "Skips creation of client during each node's initial chef-client run")
 	rootCmd.PersistentFlags().Float64P("node_replacement_rate", "R", 0.0, "How frequently (0.0 - 1.0) are new nodes generated and old ones no longer run. Default 0.0")
+	rootCmd.PersistentFlags().StringP("load_mode", "m", "policyfile", "Load mode: 'legacy' (recipes/roles/environments), 'policyfile', or 'mixed'")
+	rootCmd.PersistentFlags().String("policy_name", "", "Policyfile policy name used when load_mode is 'policyfile' or 'mixed'")
+	rootCmd.PersistentFlags().String("policy_group", "", "Policyfile policy group used when load_mode is 'policyfile' or 'mixed'")
+	rootCmd.PersistentFlags().Float64("policyfile_percentage", 0.5, "Fraction (0.0-1.0) of nodes using policyfile when load_mode is 'mixed'")
+	rootCmd.PersistentFlags().Bool("enable_compliance_phase", false, "Simulate the chef-client built-in compliance phase (sends inspec_report after each CCR)")
+	rootCmd.PersistentFlags().Float64("compliance_phase_percentage", 1.0, "Fraction (0.0-1.0) of nodes that run the compliance phase when enable_compliance_phase is true")
 	viper.BindPFlags(rootCmd.PersistentFlags())
 }
 

--- a/lib/chef_client_run.go
+++ b/lib/chef_client_run.go
@@ -53,6 +53,8 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 		reportingAvailable     = true
 		dataCollectorAvailable = true
 		expandedRunList        []string
+		expandedRunListID      string
+		policy                 PolicyDocument
 		node                   chef.Node
 		nodeDetails            = NodeDetails{
 			name:        nodeName,
@@ -62,13 +64,42 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 			recipes:     recipes,
 			nodeUUID:    nodeUUID,
 			sourceFqdn:  chefServerFQDN,
-			fqdn:        node.Name,
+			// fqdn is the node's own hostname; use nodeName as the best
+			// available value at construction time (node hasn't been fetched yet).
+			fqdn:        nodeName,
 			orgName:     orgName,
 			policyGroup: "hello_policy_group",
 			policyName:  "hello_policy_name",
 			chefTags:    []string{"tag1", "tag2", "tag3"},
 		}
 	)
+
+	// Determine whether this node slot should simulate a policyfile-based
+	// chef-client run.  Three load modes are supported:
+	//   "legacy"     – traditional run-list/roles/environments (original behaviour)
+	//   "policyfile" – every node uses the policyfile API
+	//   "mixed"      – a deterministic fraction of node slots use policyfile;
+	//                  the rest follow the traditional path.
+	usePolicyfile := false
+	switch config.LoadMode {
+	case "policyfile":
+		usePolicyfile = true
+	case "mixed":
+		usePolicyfile = float64(nodeNumber)/float64(config.NumNodes) < config.PolicyfilePercentage
+	}
+
+	// For policyfile nodes update nodeDetails to carry the real policy identity
+	// (used in compliance reports sent to Automate) and set the correct
+	// expanded_run_list id for the data-collector run_converge message.
+	if usePolicyfile {
+		nodeDetails.policyName = config.PolicyName
+		nodeDetails.policyGroup = config.PolicyGroup
+		// For policyfile nodes chef-client sets chef_environment to the policy group.
+		nodeDetails.environment = config.PolicyGroup
+		expandedRunListID = "_policy_node"
+	} else {
+		expandedRunListID = chefEnvironment
+	}
 	// Notify orchestrator when done.  THere's probably a cleaner way to
 	// do this.
 	closer := func() {
@@ -123,7 +154,12 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 			}
 		}
 		if res != nil && res.StatusCode == 404 {
-			node = chef.Node{Name: nodeName, Environment: chefEnvironment}
+			// Create the node with the correct identity for the run mode.
+			if usePolicyfile {
+				node = chef.Node{Name: nodeName, PolicyName: config.PolicyName, PolicyGroup: config.PolicyGroup}
+			} else {
+				node = chef.Node{Name: nodeName, Environment: chefEnvironment}
+			}
 			_, err = apiRequest(nodeClient, nodeName, config.ChefVersion, "POST", "nodes", node, nil, nil, requests)
 			if err != nil {
 				node = chef.Node{Name: nodeName}
@@ -132,24 +168,56 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 	} else {
 		node = chef.Node{Name: nodeName}
 	}
-	node.Environment = chefEnvironment
 	node.AutomaticAttributes = ohaiJSON
 
-	if config.RunChefClient {
-		// Expand run_list
-		numLists := len(runLists)
-		rl := runList
-		if numLists > 0 {
-			rl = runLists[rand.Intn(numLists)]
-		}
-		expandedRunList = rl.expand(&nodeClient, nodeName, config.ChefVersion, chefEnvironment, requests)
-		apiRequest(nodeClient, nodeName, config.ChefVersion, "GET", "environments/"+chefEnvironment, nil, nil, nil, requests)
+	// Apply node identity fields based on the run mode.
+	if usePolicyfile {
+		node.PolicyName = config.PolicyName
+		node.PolicyGroup = config.PolicyGroup
+		// chef-client sets chef_environment to the policy group for policyfile nodes.
+		node.Environment = config.PolicyGroup
+	} else {
+		node.Environment = chefEnvironment
+	}
 
-		// Notify Reporting of run start
-		if config.EnableReporting {
-			res, _ := reportingRunStart(nodeClient, nodeName, config.ChefVersion, runUUID, startTime, requests)
-			if res != nil && res.StatusCode == 404 {
-				reportingAvailable = false
+	if config.RunChefClient {
+		if usePolicyfile {
+			// --- Policyfile API flow ---
+			// Fetch the policyfile document from the Chef Server.
+			// This replaces run-list expansion + environment fetch.
+			policy, _ = fetchPolicy(nodeClient, nodeName, config.ChefVersion, config.PolicyGroup, config.PolicyName, requests)
+
+			// Set policyfile-specific automatic attributes on the node so that the
+			// node object saved to the server (PUT nodes/<name>) and the data
+			// collector run_converge message carry the correct metadata.
+			node.AutomaticAttributes["policy_name"] = config.PolicyName
+			node.AutomaticAttributes["policy_group"] = config.PolicyGroup
+			node.AutomaticAttributes["chef_environment"] = config.PolicyGroup
+			node.AutomaticAttributes["policy_revision"] = policy.RevisionID
+			node.AutomaticAttributes["roles"] = []string{}
+			node.AutomaticAttributes["recipes"] = policyRunListRecipes(policy.RunList)
+
+			// The node's run_list is derived directly from the policy's run_list.
+			expandedRunList = policy.RunList
+
+			// Reporting is not supported for policyfile-based chef-client runs.
+		} else {
+			// --- Traditional roles/environments flow ---
+			// Expand run_list (resolving roles through the Chef Server).
+			numLists := len(runLists)
+			rl := runList
+			if numLists > 0 {
+				rl = runLists[rand.Intn(numLists)]
+			}
+			expandedRunList = rl.expand(&nodeClient, nodeName, config.ChefVersion, chefEnvironment, requests)
+			apiRequest(nodeClient, nodeName, config.ChefVersion, "GET", "environments/"+chefEnvironment, nil, nil, nil, requests)
+
+			// Notify Reporting of run start.
+			if config.EnableReporting {
+				res, _ := reportingRunStart(nodeClient, nodeName, config.ChefVersion, runUUID, startTime, requests)
+				if res != nil && res.StatusCode == 404 {
+					reportingAvailable = false
+				}
 			}
 		}
 	}
@@ -179,23 +247,34 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 		}
 	}
 
+	var dlCookbookFileChance = config.DownloadCookbooksScaleFactor
+	var doDownload = false
+	if config.DownloadCookbooks == "first" && firstRun {
+		doDownload = true
+		dlCookbookFileChance = 1.0
+	}
+
 	if config.RunChefClient {
-		// Request resolved expanded runlist from the server
-		ckbks := solveRunListDependencies(&nodeClient, nodeName, config.ChefVersion, chefEnvironment, expandedRunList, requests)
-		// Download cookbooks
-		var dlCookbookFileChance = config.DownloadCookbooksScaleFactor
-		var doDownload = false
-		if config.DownloadCookbooks == "first" && firstRun {
-			doDownload = true
-			dlCookbookFileChance = 1.0
-		}
+		if usePolicyfile {
+			// --- Policyfile cookbook resolution ---
+			// Fetch each cookbook artifact manifest from cookbook_artifacts/<name>/<identifier>.
+			// This replaces the POST environments/<env>/cookbook_versions call used by the
+			// traditional flow.  File downloads are gated by the same download_cookbooks
+			// and download_cookbooks_scale_factor settings as the traditional path.
+			resolveAndDownloadPolicyfileCookbooks(
+				&nodeClient, nodeName, config.ChefVersion,
+				policy, doDownload, dlCookbookFileChance, requests)
+		} else {
+			// --- Traditional cookbook resolution ---
+			// Request resolved cookbook versions from environments/<env>/cookbook_versions.
+			ckbks := solveRunListDependencies(&nodeClient, nodeName, config.ChefVersion, chefEnvironment, expandedRunList, requests)
+			if doDownload || config.DownloadCookbooks == "always" {
+				ckbks.download(&nodeClient, nodeName, config.ChefVersion, dlCookbookFileChance, requests)
+			}
 
-		if doDownload || config.DownloadCookbooks == "always" {
-			ckbks.download(&nodeClient, nodeName, config.ChefVersion, dlCookbookFileChance, requests)
-		}
-
-		for _, apiGetRequest := range apiGetRequests {
-			apiRequest(nodeClient, nodeName, config.ChefVersion, "GET", apiGetRequest, nil, nil, nil, requests)
+			for _, apiGetRequest := range apiGetRequests {
+				apiRequest(nodeClient, nodeName, config.ChefVersion, "GET", apiGetRequest, nil, nil, nil, requests)
+			}
 		}
 	} else {
 		expandedRunList = runList.toStringSlice()
@@ -203,7 +282,13 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 
 	time.Sleep(time.Duration(sleepDuration) * time.Second)
 
-	node.RunList = runList.toStringSlice()
+	// For policyfile nodes the node's run_list comes from the policy document.
+	// For traditional nodes it comes from the configured run_list.
+	if usePolicyfile {
+		node.RunList = expandedRunList
+	} else {
+		node.RunList = runList.toStringSlice()
+	}
 
 	// Ensure that at least an empty set of tags is set for the node's normal attributes
 	if node.NormalAttributes == nil {
@@ -222,15 +307,23 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 			apiRequest(nodeClient, nodeName, config.ChefVersion, "PUT", "nodes/"+nodeName, node, nil, nil, requests)
 		}
 
-		// Notify Reporting of run end
-		if config.EnableReporting && reportingAvailable {
+		// Reporting is only supported for traditional (non-policyfile) runs.
+		if !usePolicyfile && config.EnableReporting && reportingAvailable {
 			reportingRunStop(nodeClient, nodeName, config.ChefVersion, runUUID, startTime, endTime, runList, requests)
 		}
 	}
 
+	// For the data collector run_converge message, policyfile nodes report their
+	// run_list as the policy's recipe list (already fully expanded).  Traditional
+	// nodes use the config run_list.
+	convergeRunList := runList
+	if usePolicyfile {
+		convergeRunList = parseRunList(expandedRunList)
+	}
+
 	// Notify Data Collector of run end
-	runStopBody := dataCollectorRunStop(config, node, nodeName, chefServerFQDN, orgName, status, runList,
-		parseRunList(expandedRunList), runUUID, nodeUUID, startTime, endTime, convergeJSON)
+	runStopBody := dataCollectorRunStop(config, node, nodeName, chefServerFQDN, orgName, status, convergeRunList,
+		parseRunList(expandedRunList), runUUID, nodeUUID, startTime, endTime, convergeJSON, expandedRunListID)
 	if config.DataCollectorURL != "" {
 		chefAutomateSendMessage(dataCollectorClient, nodeName, runStopBody)
 	} else if dataCollectorAvailable {
@@ -248,9 +341,28 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 		apiRequest(nodeClient, ccrAction.String(), config.ChefVersion, "POST", "data-collector", ccrAction, nil, nil, requests)
 	}
 
-	// Notify Data Collector of compliance report
-	if len(complianceJSON) != 0 {
-		complianceReportBody := dataCollectorComplianceReport(nodeDetails, reportUUID, endTime, complianceJSON)
+	// Notify Data Collector of compliance report.
+	//
+	// The compliance phase fires when:
+	//   1. A compliance_status_json_file was loaded (legacy file-gated behaviour), OR
+	//   2. enable_compliance_phase is true AND this node slot falls within the
+	//      compliance_phase_percentage fraction of the pool.
+	//
+	// This mirrors chef-client's built-in compliance phase (Chef Infra Client 17+)
+	// which runs InSpec at the end of every converge and sends an inspec_report
+	// message linked to the CCR via run_uuid.
+	runCompliancePhase := len(complianceJSON) != 0 ||
+		(config.EnableCompliancePhase && config.NumNodes > 0 &&
+			float64(nodeNumber) < float64(config.NumNodes)*config.CompliancePhasePercentage)
+
+	if runCompliancePhase {
+		compBody := complianceJSON
+		if len(compBody) == 0 {
+			// No file provided — use a minimal synthetic InSpec report that
+			// represents a compliance phase run with no profiles configured.
+			compBody = syntheticComplianceReport()
+		}
+		complianceReportBody := dataCollectorComplianceReport(nodeDetails, reportUUID, runUUID, endTime, compBody)
 		if config.DataCollectorURL != "" {
 			chefAutomateSendMessage(dataCollectorClient, nodeName, complianceReportBody)
 		} else {

--- a/lib/chef_client_run.go
+++ b/lib/chef_client_run.go
@@ -88,14 +88,24 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 		usePolicyfile = float64(nodeNumber)/float64(config.NumNodes) < config.PolicyfilePercentage
 	}
 
+	// When multiple policyfiles are configured, pick one at random for this run.
+	// This mirrors how run_lists works for legacy nodes — each simulated run
+	// gets a randomly selected policy name from the pool. All names are fetched
+	// from the same policy_group; policy_name is ignored when the list is set.
+	activePolicyName := config.PolicyName
+	activePolicyGroup := config.PolicyGroup
+	if len(config.Policyfiles) > 0 {
+		activePolicyName = config.Policyfiles[rand.Intn(len(config.Policyfiles))]
+	}
+
 	// For policyfile nodes update nodeDetails to carry the real policy identity
 	// (used in compliance reports sent to Automate) and set the correct
 	// expanded_run_list id for the data-collector run_converge message.
 	if usePolicyfile {
-		nodeDetails.policyName = config.PolicyName
-		nodeDetails.policyGroup = config.PolicyGroup
+		nodeDetails.policyName = activePolicyName
+		nodeDetails.policyGroup = activePolicyGroup
 		// For policyfile nodes chef-client sets chef_environment to the policy group.
-		nodeDetails.environment = config.PolicyGroup
+		nodeDetails.environment = activePolicyGroup
 		expandedRunListID = "_policy_node"
 	} else {
 		expandedRunListID = chefEnvironment
@@ -156,7 +166,7 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 		if res != nil && res.StatusCode == 404 {
 			// Create the node with the correct identity for the run mode.
 			if usePolicyfile {
-				node = chef.Node{Name: nodeName, PolicyName: config.PolicyName, PolicyGroup: config.PolicyGroup}
+				node = chef.Node{Name: nodeName, PolicyName: activePolicyName, PolicyGroup: activePolicyGroup}
 			} else {
 				node = chef.Node{Name: nodeName, Environment: chefEnvironment}
 			}
@@ -172,10 +182,10 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 
 	// Apply node identity fields based on the run mode.
 	if usePolicyfile {
-		node.PolicyName = config.PolicyName
-		node.PolicyGroup = config.PolicyGroup
+		node.PolicyName = activePolicyName
+		node.PolicyGroup = activePolicyGroup
 		// chef-client sets chef_environment to the policy group for policyfile nodes.
-		node.Environment = config.PolicyGroup
+		node.Environment = activePolicyGroup
 	} else {
 		node.Environment = chefEnvironment
 	}
@@ -185,14 +195,14 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 			// --- Policyfile API flow ---
 			// Fetch the policyfile document from the Chef Server.
 			// This replaces run-list expansion + environment fetch.
-			policy, _ = fetchPolicy(nodeClient, nodeName, config.ChefVersion, config.PolicyGroup, config.PolicyName, requests)
+			policy, _ = fetchPolicy(nodeClient, nodeName, config.ChefVersion, activePolicyGroup, activePolicyName, requests)
 
 			// Set policyfile-specific automatic attributes on the node so that the
 			// node object saved to the server (PUT nodes/<name>) and the data
 			// collector run_converge message carry the correct metadata.
-			node.AutomaticAttributes["policy_name"] = config.PolicyName
-			node.AutomaticAttributes["policy_group"] = config.PolicyGroup
-			node.AutomaticAttributes["chef_environment"] = config.PolicyGroup
+			node.AutomaticAttributes["policy_name"] = activePolicyName
+			node.AutomaticAttributes["policy_group"] = activePolicyGroup
+			node.AutomaticAttributes["chef_environment"] = activePolicyGroup
 			node.AutomaticAttributes["policy_revision"] = policy.RevisionID
 			node.AutomaticAttributes["roles"] = []string{}
 			node.AutomaticAttributes["recipes"] = policyRunListRecipes(policy.RunList)

--- a/lib/compliance_generator.go
+++ b/lib/compliance_generator.go
@@ -215,7 +215,7 @@ func generateReports(config *Config, nodes []NodeDetails, requests chan *request
 			report := sampleReport
 			reportUUID := uuid.New()
 			reportEndTime := endTime.Add(time.Duration(-interval*scanIndex) * time.Minute)
-			complianceReportBody := dataCollectorComplianceReport(node, reportUUID, reportEndTime, report)
+			complianceReportBody := dataCollectorComplianceReport(node, reportUUID, uuid.Nil, reportEndTime, report)
 
 			if config.DataCollectorURL != "" {
 				chefAutomateSendMessage(dataCollectorClient, node.name, complianceReportBody)

--- a/lib/config.go
+++ b/lib/config.go
@@ -89,6 +89,29 @@ type Config struct {
 	Matrix                       *Matrix    `mapstructure:"matrix"`
 	SkipClientCreation           bool       `mapstructure:"skip_client_creation"`
 	NodeReplacementRate          float64    `mapstructure:"node_replacement_rate"`
+
+	// Policyfile simulation settings.
+	// LoadMode controls which API flow nodes simulate:
+	//   "legacy"     – traditional run-list/roles/environments (original behaviour)
+	//   "policyfile" – all nodes use the policyfile API
+	//   "mixed"      – a fraction of nodes use policyfile (see PolicyfilePercentage)
+	LoadMode             string  `mapstructure:"load_mode"`
+	PolicyName           string  `mapstructure:"policy_name"`
+	PolicyGroup          string  `mapstructure:"policy_group"`
+	PolicyfilePercentage float64 `mapstructure:"policyfile_percentage"`
+
+	// Compliance phase simulation settings.
+	// EnableCompliancePhase simulates the built-in chef-client compliance phase
+	// (Chef Infra Client 17+) by sending an inspec_report message to the data
+	// collector at the end of each simulated chef-client run.
+	// When false (default), compliance reports are only sent if
+	// compliance_status_json_file is set (legacy behaviour).
+	EnableCompliancePhase    bool    `mapstructure:"enable_compliance_phase"`
+	// CompliancePhasePercentage controls what fraction (0.0–1.0) of simulated
+	// nodes run the compliance phase when enable_compliance_phase is true.
+	// Use 1.0 to enable it for every node or a smaller value to simulate
+	// an environment where only some nodes have the compliance phase configured.
+	CompliancePhasePercentage float64 `mapstructure:"compliance_phase_percentage"`
 }
 
 func Default() Config {
@@ -123,6 +146,12 @@ func Default() Config {
 		SleepTimeOnFailure:           5,
 		SkipClientCreation:           false,
 		NodeReplacementRate:          0.0,
+		LoadMode:                     "policyfile",
+		PolicyName:                   "",
+		PolicyGroup:                  "",
+		PolicyfilePercentage:         0.5,
+		EnableCompliancePhase:        false,
+		CompliancePhasePercentage:    1.0,
 		Matrix: &Matrix{
 			Simulation: Simulation{
 				Days:          1,
@@ -306,6 +335,44 @@ func PrintSampleConfig() {
 # which will force every chef-client run to be from a new node/client.
 
 # node_replacement_rate = 0.0
+
+# load_mode controls which chef-client API flow is simulated for each node.
+# Options are:
+#   "legacy"     - traditional run-list/roles/environments-based chef-client run (original behaviour)
+#   "policyfile" - all nodes use the policyfile API (policy_groups/<group>/policies/<name>)
+#   "mixed"      - a fraction of nodes (policyfile_percentage) use the policyfile API;
+#                  the remainder use the traditional run-list/roles/environments flow
+# load_mode = "policyfile"
+
+# policy_name is the name of the policyfile policy to simulate.
+# Required when load_mode is "policyfile" or "mixed" and run_chef_client is true.
+# policy_name = ""
+
+# policy_group is the policy group to use when fetching the policyfile from the
+# Chef Server (GET policy_groups/<group>/policies/<name>).
+# Required when load_mode is "policyfile" or "mixed" and run_chef_client is true.
+# policy_group = ""
+
+# policyfile_percentage sets what fraction (0.0-1.0) of simulated nodes use the
+# policyfile API when load_mode = "mixed". Nodes are assigned deterministically
+# so that exactly this fraction of the node pool runs the policyfile flow.
+# Ignored when load_mode is "legacy" or "policyfile".
+# policyfile_percentage = 0.5
+
+# enable_compliance_phase simulates the built-in compliance phase introduced in
+# Chef Infra Client 17+. When true, an inspec_report message is sent to the
+# data collector at the end of each simulated chef-client run, linked to the
+# CCR via run_uuid (matching actual chef-client behaviour).
+# If compliance_status_json_file is set, that file's content is used as the
+# report body; otherwise a minimal synthetic report is sent representing a node
+# with no InSpec profiles configured.
+# enable_compliance_phase = false
+
+# compliance_phase_percentage controls what fraction (0.0-1.0) of simulated
+# nodes run the compliance phase when enable_compliance_phase is true.
+# Set to 1.0 (default) to enable compliance on all nodes, or a smaller value
+# to model an environment where only a subset of nodes have profiles assigned.
+# compliance_phase_percentage = 1.0
 
 # Send data to the Chef server's Reporting service
 # enable_reporting = false

--- a/lib/config.go
+++ b/lib/config.go
@@ -95,10 +95,11 @@ type Config struct {
 	//   "legacy"     – traditional run-list/roles/environments (original behaviour)
 	//   "policyfile" – all nodes use the policyfile API
 	//   "mixed"      – a fraction of nodes use policyfile (see PolicyfilePercentage)
-	LoadMode             string  `mapstructure:"load_mode"`
-	PolicyName           string  `mapstructure:"policy_name"`
-	PolicyGroup          string  `mapstructure:"policy_group"`
-	PolicyfilePercentage float64 `mapstructure:"policyfile_percentage"`
+	LoadMode             string           `mapstructure:"load_mode"`
+	PolicyName           string           `mapstructure:"policy_name"`
+	PolicyGroup          string           `mapstructure:"policy_group"`
+	Policyfiles          []string         `mapstructure:"policyfiles"`
+	PolicyfilePercentage float64          `mapstructure:"policyfile_percentage"`
 
 	// Compliance phase simulation settings.
 	// EnableCompliancePhase simulates the built-in chef-client compliance phase
@@ -149,6 +150,7 @@ func Default() Config {
 		LoadMode:                     "policyfile",
 		PolicyName:                   "",
 		PolicyGroup:                  "",
+		Policyfiles:                  make([]string, 0),
 		PolicyfilePercentage:         0.5,
 		EnableCompliancePhase:        false,
 		CompliancePhasePercentage:    1.0,
@@ -345,13 +347,24 @@ func PrintSampleConfig() {
 # load_mode = "policyfile"
 
 # policy_name is the name of the policyfile policy to simulate.
-# Required when load_mode is "policyfile" or "mixed" and run_chef_client is true.
+# Required when load_mode is "policyfile" or "mixed", run_chef_client is true,
+# and policyfiles is empty.
 # policy_name = ""
 
 # policy_group is the policy group to use when fetching the policyfile from the
 # Chef Server (GET policy_groups/<group>/policies/<name>).
 # Required when load_mode is "policyfile" or "mixed" and run_chef_client is true.
+# When policyfiles is set, all listed policy names are fetched from this group.
 # policy_group = ""
+
+# policyfiles is an optional list of policy names. When provided, each simulated
+# chef-client run randomly picks one name from the list — all nodes use the same
+# policy_group. This mirrors how run_lists works for legacy nodes and is useful
+# when your fleet runs several different policies within the same policy group.
+# If this value is non-empty, policy_name is ignored.
+# All listed policies must exist in the configured policy_group on the Chef Server.
+#
+# policyfiles = [ "base", "webserver", "database" ]
 
 # policyfile_percentage sets what fraction (0.0-1.0) of simulated nodes use the
 # policyfile API when load_mode = "mixed". Nodes are assigned deterministically

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -45,6 +45,11 @@ func TestDefault_CompliancePhasePercentage(t *testing.T) {
 	assert.Equal(t, 1.0, cfg.CompliancePhasePercentage)
 }
 
+func TestDefault_Policyfiles(t *testing.T) {
+	cfg := Default()
+	assert.Empty(t, cfg.Policyfiles, "policyfiles should default to an empty slice")
+}
+
 func TestDefault_PolicyNameAndGroup(t *testing.T) {
 	cfg := Default()
 	assert.Empty(t, cfg.PolicyName)
@@ -158,4 +163,49 @@ func TestCompliancePhaseGate_EnabledHalfNodes(t *testing.T) {
 func TestCompliancePhaseGate_ZeroNodes(t *testing.T) {
 	// Guard against divide-by-zero: NumNodes == 0 must never fire.
 	assert.False(t, runCompliancePhaseFor(false, true, 0, 0, 1.0))
+}
+
+// --- policyfiles random selection logic ---
+// selectPolicyfileForTest mirrors the selection logic in ChefClientRun.
+func selectPolicyfileForTest(policyName string, policyfiles []string, idx int) string {
+	activeName := policyName
+	if len(policyfiles) > 0 {
+		activeName = policyfiles[idx%len(policyfiles)]
+	}
+	return activeName
+}
+
+func TestSelectPolicyfile_EmptyListUsesScalar(t *testing.T) {
+	assert.Equal(t, "base", selectPolicyfileForTest("base", nil, 0))
+}
+
+func TestSelectPolicyfile_SingleEntryAlwaysPicked(t *testing.T) {
+	entries := []string{"web"}
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, "web", selectPolicyfileForTest("ignored", entries, i))
+	}
+}
+
+func TestSelectPolicyfile_MultipleEntriesAllReachable(t *testing.T) {
+	entries := []string{"base", "webserver", "database"}
+	seen := map[string]bool{}
+	for i := 0; i < len(entries); i++ {
+		seen[selectPolicyfileForTest("", entries, i)] = true
+	}
+	assert.True(t, seen["base"], "base should be reachable")
+	assert.True(t, seen["webserver"], "webserver should be reachable")
+	assert.True(t, seen["database"], "database should be reachable")
+}
+
+func TestSelectPolicyfile_ScalarIgnoredWhenListNonEmpty(t *testing.T) {
+	name := selectPolicyfileForTest("scalar_name", []string{"override"}, 0)
+	assert.Equal(t, "override", name)
+}
+
+func TestSelectPolicyfile_AllNodesShareSamePolicyGroup(t *testing.T) {
+	// The policy_group is always taken from config; only the name varies.
+	// This test documents that assumption: the helper only returns a name.
+	entries := []string{"base", "webserver"}
+	assert.Equal(t, "base", selectPolicyfileForTest("", entries, 0))
+	assert.Equal(t, "webserver", selectPolicyfileForTest("", entries, 1))
 }

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -1,0 +1,161 @@
+//
+// Copyright:: Copyright 2017-2018 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package chef_load
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Default() ---
+
+func TestDefault_LoadMode(t *testing.T) {
+	cfg := Default()
+	assert.Equal(t, "policyfile", cfg.LoadMode)
+}
+
+func TestDefault_PolicyfilePercentage(t *testing.T) {
+	cfg := Default()
+	assert.Equal(t, 0.5, cfg.PolicyfilePercentage)
+}
+
+func TestDefault_EnableCompliancePhase(t *testing.T) {
+	cfg := Default()
+	assert.False(t, cfg.EnableCompliancePhase)
+}
+
+func TestDefault_CompliancePhasePercentage(t *testing.T) {
+	cfg := Default()
+	assert.Equal(t, 1.0, cfg.CompliancePhasePercentage)
+}
+
+func TestDefault_PolicyNameAndGroup(t *testing.T) {
+	cfg := Default()
+	assert.Empty(t, cfg.PolicyName)
+	assert.Empty(t, cfg.PolicyGroup)
+}
+
+func TestDefault_LegacyDefaults(t *testing.T) {
+	// Verify pre-existing defaults haven't changed.
+	cfg := Default()
+	assert.Equal(t, 30, cfg.NumNodes)
+	assert.Equal(t, 30, cfg.Interval)
+	assert.Equal(t, "chef-load", cfg.NodeNamePrefix)
+	assert.Equal(t, "_default", cfg.ChefEnvironment)
+	assert.Equal(t, "never", cfg.DownloadCookbooks)
+	assert.Equal(t, 1.0, cfg.DownloadCookbooksScaleFactor)
+	assert.Equal(t, "13.2.20", cfg.ChefVersion)
+	assert.False(t, cfg.RunChefClient)
+	assert.False(t, cfg.SkipClientCreation)
+	assert.Equal(t, 0.0, cfg.NodeReplacementRate)
+}
+
+// --- PrintSampleConfig ---
+
+func TestPrintSampleConfig_ContainsNewSettings(t *testing.T) {
+	// PrintSampleConfig writes to stdout; the simplest approach is to verify
+	// that the function runs without panic (it is tested implicitly via the
+	// init command). We also use it as a hook to ensure the documented options
+	// actually exist in the Config struct so that mapstructure can load them.
+	cfg := Default()
+
+	// Ensure every new TOML key maps to a real field.
+	assert.NotEmpty(t, cfg.LoadMode)
+	assert.False(t, cfg.EnableCompliancePhase)
+	assert.Equal(t, 1.0, cfg.CompliancePhasePercentage)
+	assert.Equal(t, 0.5, cfg.PolicyfilePercentage)
+}
+
+// --- usePolicyfile determination logic ---
+// The switch logic lives inside ChefClientRun but we can unit-test it by
+// extracting the same expression.
+
+func policyfileModeFor(loadMode string, nodeNumber uint32, numNodes int, pct float64) bool {
+	switch loadMode {
+	case "policyfile":
+		return true
+	case "mixed":
+		return float64(nodeNumber)/float64(numNodes) < pct
+	}
+	return false
+}
+
+func TestUsePolicyfile_PolicyfileMode(t *testing.T) {
+	assert.True(t, policyfileModeFor("policyfile", 0, 100, 0.5))
+	assert.True(t, policyfileModeFor("policyfile", 99, 100, 0.0))
+}
+
+func TestUsePolicyfile_LegacyMode(t *testing.T) {
+	assert.False(t, policyfileModeFor("legacy", 0, 100, 1.0))
+}
+
+func TestUsePolicyfile_MixedMode_FirstHalf(t *testing.T) {
+	// With 50% and 100 nodes, slots 0-49 should use policyfile.
+	assert.True(t, policyfileModeFor("mixed", 0, 100, 0.5))
+	assert.True(t, policyfileModeFor("mixed", 49, 100, 0.5))
+}
+
+func TestUsePolicyfile_MixedMode_SecondHalf(t *testing.T) {
+	// Slots 50-99 should use legacy.
+	assert.False(t, policyfileModeFor("mixed", 50, 100, 0.5))
+	assert.False(t, policyfileModeFor("mixed", 99, 100, 0.5))
+}
+
+func TestUsePolicyfile_MixedMode_AllPolicyfile(t *testing.T) {
+	assert.True(t, policyfileModeFor("mixed", 99, 100, 1.0))
+}
+
+func TestUsePolicyfile_MixedMode_NoPolicyfile(t *testing.T) {
+	assert.False(t, policyfileModeFor("mixed", 0, 100, 0.0))
+}
+
+// --- compliance phase gate logic ---
+
+func runCompliancePhaseFor(hasFile bool, enabled bool, nodeNumber uint32, numNodes int, pct float64) bool {
+	fileLoaded := hasFile
+	return fileLoaded || (enabled && numNodes > 0 && float64(nodeNumber) < float64(numNodes)*pct)
+}
+
+func TestCompliancePhaseGate_FileAlwaysFires(t *testing.T) {
+	// If a compliance JSON file is loaded, always fire regardless of other settings.
+	assert.True(t, runCompliancePhaseFor(true, false, 0, 100, 0.0))
+}
+
+func TestCompliancePhaseGate_DisabledWithNoFile(t *testing.T) {
+	assert.False(t, runCompliancePhaseFor(false, false, 0, 100, 1.0))
+}
+
+func TestCompliancePhaseGate_EnabledAllNodes(t *testing.T) {
+	for i := uint32(0); i < 10; i++ {
+		assert.True(t, runCompliancePhaseFor(false, true, i, 10, 1.0),
+			"node %d should run compliance with 100%% coverage", i)
+	}
+}
+
+func TestCompliancePhaseGate_EnabledHalfNodes(t *testing.T) {
+	assert.True(t, runCompliancePhaseFor(false, true, 0, 10, 0.5))
+	assert.True(t, runCompliancePhaseFor(false, true, 4, 10, 0.5))
+	assert.False(t, runCompliancePhaseFor(false, true, 5, 10, 0.5))
+	assert.False(t, runCompliancePhaseFor(false, true, 9, 10, 0.5))
+}
+
+func TestCompliancePhaseGate_ZeroNodes(t *testing.T) {
+	// Guard against divide-by-zero: NumNodes == 0 must never fire.
+	assert.False(t, runCompliancePhaseFor(false, true, 0, 0, 1.0))
+}

--- a/lib/data_collector.go
+++ b/lib/data_collector.go
@@ -172,9 +172,14 @@ func dataCollectorRunStart(config *Config, nodeName, chefServerFQDN, orgName str
 }
 
 // TODO: (@afiune) Refactor this so we dont pass so many arguments
+// expandedRunListID is the value used for the "id" field of the expanded_run_list
+// object in the run_converge data collector message.  For traditional
+// environment/role-based runs this should be the chef environment name
+// (e.g. "_default").  For policyfile-based runs it must be "_policy_node".
 func dataCollectorRunStop(config *Config, node chef.Node, nodeName, chefServerFQDN, orgName, status string,
 	runList, expandedRunList runList, runUUID, nodeUUID uuid.UUID,
-	startTime, endTime time.Time, convergeJSON map[string]interface{}) interface{} {
+	startTime, endTime time.Time, convergeJSON map[string]interface{},
+	expandedRunListID string) interface{} {
 
 	convergedRunList := []interface{}{}
 	convergedExpandedRunListMap := map[string]interface{}{}
@@ -206,7 +211,7 @@ func dataCollectorRunStop(config *Config, node chef.Node, nodeName, chefServerFQ
 		}
 
 		convergedExpandedRunListMap = map[string]interface{}{
-			"id":       config.ChefEnvironment,
+			"id":       expandedRunListID,
 			"run_list": expandedRunListItemsInterface,
 		}
 	}
@@ -239,13 +244,30 @@ func dataCollectorRunStop(config *Config, node chef.Node, nodeName, chefServerFQ
 	return body
 }
 
-func dataCollectorComplianceReport(node NodeDetails, reportUUID uuid.UUID, endTime time.Time, complianceJSON map[string]interface{}) interface{} {
+// syntheticComplianceReport returns a minimal but structurally valid InSpec
+// JSON report body for use when the compliance phase is enabled but no
+// compliance_status_json_file has been provided.  It matches the shape
+// produced by InSpec's json-automate reporter with no profiles configured,
+// which is what a freshly bootstrapped node with compliance phase enabled
+// but no profiles assigned would send.
+func syntheticComplianceReport() map[string]interface{} {
+	return map[string]interface{}{
+		"version":    "6.0.0",
+		"statistics": map[string]interface{}{"duration": 0.001},
+		"profiles":   []interface{}{},
+	}
+}
+
+func dataCollectorComplianceReport(node NodeDetails, reportUUID, runUUID uuid.UUID, endTime time.Time, complianceJSON map[string]interface{}) interface{} {
 	body := complianceJSON
 	body["type"] = "inspec_report"
 	body["node_name"] = node.name
 	body["environment"] = node.environment
 	body["report_uuid"] = reportUUID
 	body["node_uuid"] = node.nodeUUID
+	// run_uuid links this compliance report back to the chef-client CCR that
+	// triggered it, matching what chef-client's compliance phase sends.
+	body["run_uuid"] = runUUID
 	body["roles"] = node.roles
 	body["recipes"] = node.recipes
 	body["end_time"] = endTime.Format(DateTimeFormat)

--- a/lib/data_collector_test.go
+++ b/lib/data_collector_test.go
@@ -1,0 +1,238 @@
+//
+// Copyright:: Copyright 2017-2018 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package chef_load
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-chef/chef"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// helpers
+
+func testNodeDetails() NodeDetails {
+	return NodeDetails{
+		name:        "test-node",
+		environment: "production",
+		ipAddr:      "10.0.0.1",
+		fqdn:        "test-node.example.com",
+		sourceFqdn:  "chef.example.com",
+		orgName:     "myorg",
+		policyName:  "base",
+		policyGroup: "prod",
+		chefTags:    []string{"tag1"},
+		roles:       []string{"web"},
+		recipes:     []string{"base::default"},
+		nodeUUID:    uuid.NewMD5(uuid.NameSpaceDNS, []byte("test-node")),
+	}
+}
+
+func testConfig() *Config {
+	cfg := Default()
+	cfg.ChefServerURL = "https://chef.example.com/organizations/myorg"
+	cfg.DataCollectorToken = "test-token"
+	cfg.ChefVersion = "18.0.0"
+	return &cfg
+}
+
+// --- syntheticComplianceReport ---
+
+func TestSyntheticComplianceReport_Shape(t *testing.T) {
+	r := syntheticComplianceReport()
+	assert.Equal(t, "6.0.0", r["version"], "version field")
+	stats, ok := r["statistics"].(map[string]interface{})
+	if !assert.True(t, ok, "statistics should be a map") {
+		return
+	}
+	assert.NotZero(t, stats["duration"], "duration field")
+	profiles, ok := r["profiles"].([]interface{})
+	if !assert.True(t, ok, "profiles should be a slice") {
+		return
+	}
+	assert.Empty(t, profiles, "profiles should be empty for synthetic report")
+}
+
+func TestSyntheticComplianceReport_ReturnsNewMapEachCall(t *testing.T) {
+	r1 := syntheticComplianceReport()
+	r2 := syntheticComplianceReport()
+	r1["version"] = "mutated"
+	assert.Equal(t, "6.0.0", r2["version"], "mutations must not bleed between calls")
+}
+
+// --- dataCollectorComplianceReport ---
+
+func TestDataCollectorComplianceReport_RequiredFields(t *testing.T) {
+	nd := testNodeDetails()
+	reportUUID := uuid.New()
+	runUUID := uuid.New()
+	endTime := time.Now().UTC()
+	body := syntheticComplianceReport()
+
+	result := dataCollectorComplianceReport(nd, reportUUID, runUUID, endTime, body).(map[string]interface{})
+
+	assert.Equal(t, "inspec_report", result["type"])
+	assert.Equal(t, nd.name, result["node_name"])
+	assert.Equal(t, nd.environment, result["environment"])
+	assert.Equal(t, nd.fqdn, result["fqdn"])
+	assert.Equal(t, nd.sourceFqdn, result["source_fqdn"])
+	assert.Equal(t, nd.orgName, result["organization_name"])
+	assert.Equal(t, nd.policyName, result["policy_name"])
+	assert.Equal(t, nd.policyGroup, result["policy_group"])
+	assert.Equal(t, nd.chefTags, result["chef_tags"])
+	assert.Equal(t, nd.ipAddr, result["ipaddress"])
+	assert.Equal(t, nd.nodeUUID, result["node_uuid"])
+	assert.Equal(t, reportUUID, result["report_uuid"])
+	assert.Equal(t, runUUID, result["run_uuid"])
+	assert.Equal(t, endTime.Format(DateTimeFormat), result["end_time"])
+}
+
+func TestDataCollectorComplianceReport_RunUUIDIsNilForStandaloneScans(t *testing.T) {
+	// Standalone compliance scans (from the generate path) should carry a nil
+	// run_uuid so the Automate ingest pipeline doesn't attempt to correlate them
+	// with a CCR.
+	nd := testNodeDetails()
+	result := dataCollectorComplianceReport(nd, uuid.New(), uuid.Nil, time.Now().UTC(),
+		syntheticComplianceReport()).(map[string]interface{})
+	assert.Equal(t, uuid.Nil, result["run_uuid"])
+}
+
+func TestDataCollectorComplianceReport_ControlsFieldStripped(t *testing.T) {
+	nd := testNodeDetails()
+	body := syntheticComplianceReport()
+	body["controls"] = []interface{}{"should-be-deleted"}
+
+	result := dataCollectorComplianceReport(nd, uuid.New(), uuid.New(), time.Now().UTC(), body).(map[string]interface{})
+	assert.Nil(t, result["controls"], "controls field must be stripped")
+}
+
+// --- dataCollectorRunStart ---
+
+func TestDataCollectorRunStart_MessageType(t *testing.T) {
+	cfg := testConfig()
+	runUUID := uuid.New()
+	nodeUUID := uuid.New()
+	startTime := time.Now().UTC()
+
+	body := dataCollectorRunStart(cfg, "test-node", "chef.example.com", "myorg", runUUID, nodeUUID, startTime).(map[string]interface{})
+
+	assert.Equal(t, "run_start", body["message_type"])
+	assert.Equal(t, "1.1.0", body["message_version"])
+	assert.Equal(t, "chef_client", body["source"])
+	assert.Equal(t, "test-node", body["node_name"])
+	assert.Equal(t, "myorg", body["organization_name"])
+	assert.Equal(t, runUUID.String(), body["run_id"])
+	assert.Equal(t, runUUID.String(), body["id"])
+	assert.Equal(t, nodeUUID.String(), body["entity_uuid"])
+	assert.Equal(t, startTime.Format(DateTimeFormat), body["start_time"])
+}
+
+func TestDataCollectorRunStart_InfersChefServerFQDN(t *testing.T) {
+	// When chefServerFQDN is empty, it should be derived from ChefServerURL.
+	cfg := testConfig()
+	body := dataCollectorRunStart(cfg, "node", "", "myorg", uuid.New(), uuid.New(), time.Now()).(map[string]interface{})
+	assert.Equal(t, "chef.example.com", body["chef_server_fqdn"])
+}
+
+// --- dataCollectorRunStop ---
+
+func testRunStopBody(t *testing.T, expandedRunListID string) map[string]interface{} {
+	t.Helper()
+	cfg := testConfig()
+	node := chef.Node{Name: "test-node"}
+	runUUID := uuid.New()
+	nodeUUID := uuid.New()
+	start := time.Now().UTC()
+	end := start.Add(30 * time.Second)
+	rl := parseRunList([]string{"recipe[base::default]"})
+
+	result := dataCollectorRunStop(cfg, node, "test-node", "chef.example.com", "myorg", "success",
+		rl, rl, runUUID, nodeUUID, start, end, map[string]interface{}{}, expandedRunListID)
+	return result.(map[string]interface{})
+}
+
+func TestDataCollectorRunStop_MessageType(t *testing.T) {
+	body := testRunStopBody(t, "_default")
+	assert.Equal(t, "run_converge", body["message_type"])
+	assert.Equal(t, "1.1.0", body["message_version"])
+	assert.Equal(t, "chef_client", body["source"])
+	assert.Equal(t, "success", body["status"])
+}
+
+func TestDataCollectorRunStop_LegacyExpandedRunListID(t *testing.T) {
+	body := testRunStopBody(t, "_default")
+	erl := body["expanded_run_list"].(map[string]interface{})
+	assert.Equal(t, "_default", erl["id"], "traditional runs use chef environment as expanded_run_list id")
+}
+
+func TestDataCollectorRunStop_PolicyfileExpandedRunListID(t *testing.T) {
+	body := testRunStopBody(t, "_policy_node")
+	erl := body["expanded_run_list"].(map[string]interface{})
+	assert.Equal(t, "_policy_node", erl["id"], "policyfile runs must use _policy_node as expanded_run_list id")
+}
+
+func TestDataCollectorRunStop_RunListContents(t *testing.T) {
+	body := testRunStopBody(t, "_default")
+	rl := body["run_list"].([]interface{})
+	if !assert.Len(t, rl, 1) {
+		return
+	}
+	assert.Equal(t, "recipe[base::default]", rl[0])
+}
+
+func TestDataCollectorRunStop_ExpandedRunListItems(t *testing.T) {
+	body := testRunStopBody(t, "_default")
+	erl := body["expanded_run_list"].(map[string]interface{})
+	items := erl["run_list"].([]interface{})
+	if !assert.Len(t, items, 1) {
+		return
+	}
+	item := items[0].(expandedRunListItem)
+	assert.Equal(t, "base::default", item.Name)
+	assert.Equal(t, "recipe", item.ItemType)
+	assert.False(t, item.Skipped)
+}
+
+func TestDataCollectorRunStop_ConvergeJSONOverridesRunList(t *testing.T) {
+	// When converge_status_json_file supplies run_list and expanded_run_list,
+	// those values must take precedence over anything computed from config.
+	cfg := testConfig()
+	node := chef.Node{Name: "test-node"}
+	runUUID := uuid.New()
+	nodeUUID := uuid.New()
+	start := time.Now().UTC()
+	end := start.Add(5 * time.Second)
+	overrideRL := []interface{}{"recipe[override::default]"}
+	overrideERL := map[string]interface{}{
+		"id":       "from-file",
+		"run_list": []interface{}{},
+	}
+	convergeJSON := map[string]interface{}{
+		"run_list":         overrideRL,
+		"expanded_run_list": overrideERL,
+	}
+
+	body := dataCollectorRunStop(cfg, node, "test-node", "chef.example.com", "myorg", "success",
+		parseRunList([]string{}), parseRunList([]string{}), runUUID, nodeUUID, start, end,
+		convergeJSON, "_default").(map[string]interface{})
+
+	assert.Equal(t, overrideRL, body["run_list"])
+	assert.Equal(t, overrideERL, body["expanded_run_list"])
+}

--- a/lib/generator.go
+++ b/lib/generator.go
@@ -463,7 +463,7 @@ func randomChefClientRun(config *Config, chefClient chef.Client, nodeName string
 
 	// Notify Data Collector of run end
 	runStopBody := dataCollectorRunStop(config, node, nodeName, chefServerFQDN, orgName, status, runList,
-		parseRunList(expandedRunList), runUUID, nodeUUID, startTime, endTime, convergeJSON)
+		parseRunList(expandedRunList), runUUID, nodeUUID, startTime, endTime, convergeJSON, node.Environment)
 	if config.DataCollectorURL != "" {
 		chefAutomateSendMessage(dataCollectorClient, nodeName, runStopBody)
 	} else if dataCollectorAvailable {

--- a/lib/policyfile.go
+++ b/lib/policyfile.go
@@ -1,0 +1,109 @@
+//
+// Copyright:: Copyright 2017-2018 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package chef_load
+
+import (
+	"strings"
+
+	"github.com/go-chef/chef"
+)
+
+// PolicyCookbookLock holds the version lock data for a single cookbook entry
+// inside a policyfile's cookbook_locks section.
+type PolicyCookbookLock struct {
+	// Identifier is the SHA1 that uniquely identifies the cookbook artifact.
+	// Used by the native policyfile API (policy_document_native_api = true).
+	Identifier string `json:"identifier"`
+
+	// DottedDecimalIdentifier is an x.y.z representation of the identifier
+	// used by the compatibility-mode policyfile API.
+	DottedDecimalIdentifier string `json:"dotted_decimal_identifier"`
+
+	// Version is the semver version string of the locked cookbook.
+	Version string `json:"version"`
+}
+
+// PolicyDocument represents the policyfile document returned by the Chef Server
+// via GET /organizations/<org>/policy_groups/<group>/policies/<name>.
+type PolicyDocument struct {
+	RevisionID         string                        `json:"revision_id"`
+	Name               string                        `json:"name"`
+	RunList            []string                      `json:"run_list"`
+	NamedRunLists      map[string][]string           `json:"named_run_lists,omitempty"`
+	CookbookLocks      map[string]PolicyCookbookLock `json:"cookbook_locks"`
+	DefaultAttributes  map[string]interface{}        `json:"default_attributes,omitempty"`
+	OverrideAttributes map[string]interface{}        `json:"override_attributes,omitempty"`
+}
+
+// fetchPolicy retrieves the policyfile document from the Chef Server using the
+// native policyfile API endpoint:
+//
+//	GET /organizations/<org>/policy_groups/<group>/policies/<name>
+func fetchPolicy(nodeClient chef.Client, nodeName, chefVersion, policyGroup, policyName string, requests chan *request) (PolicyDocument, error) {
+	var policy PolicyDocument
+	url := "policy_groups/" + policyGroup + "/policies/" + policyName
+	_, err := apiRequest(nodeClient, nodeName, chefVersion, "GET", url, nil, &policy, nil, requests)
+	return policy, err
+}
+
+// parsePolicyRecipeSpec strips the "recipe[" prefix and trailing "]" from a
+// policy run_list entry, returning the bare "cookbook::recipe" name.
+// For example: "recipe[apache::default]" -> "apache::default".
+// If the spec does not match the expected format it is returned as-is.
+func parsePolicyRecipeSpec(spec string) string {
+	if strings.HasPrefix(spec, "recipe[") && strings.HasSuffix(spec, "]") {
+		return spec[7 : len(spec)-1]
+	}
+	return spec
+}
+
+// policyRunListRecipes extracts the bare recipe names (cookbook::recipe) from a
+// policyfile run_list for use in node automatic attributes.
+func policyRunListRecipes(policyRunList []string) []string {
+	recipes := make([]string, 0, len(policyRunList))
+	for _, spec := range policyRunList {
+		recipes = append(recipes, parsePolicyRecipeSpec(spec))
+	}
+	return recipes
+}
+
+// resolveAndDownloadPolicyfileCookbooks fetches the cookbook artifact manifest for
+// each entry in the policy's cookbook_locks from the Chef Server's native
+// cookbook_artifacts endpoint:
+//
+//	GET /organizations/<org>/cookbook_artifacts/<name>/<identifier>
+//
+// When doDownload is true, individual cookbook files are downloaded with the
+// given probability (0.0–1.0).
+func resolveAndDownloadPolicyfileCookbooks(
+	nodeClient *chef.Client,
+	nodeName, chefVersion string,
+	policy PolicyDocument,
+	doDownload bool,
+	downloadProbability float64,
+	requests chan *request,
+) {
+	for name, lock := range policy.CookbookLocks {
+		var ckbk cookbook
+		url := "cookbook_artifacts/" + name + "/" + lock.Identifier
+		apiRequest(*nodeClient, nodeName, chefVersion, "GET", url, nil, &ckbk, nil, requests)
+		if doDownload {
+			ckbk.download(nodeClient, nodeName, chefVersion, downloadProbability, requests)
+		}
+	}
+}

--- a/lib/policyfile_test.go
+++ b/lib/policyfile_test.go
@@ -1,0 +1,80 @@
+//
+// Copyright:: Copyright 2017-2018 Chef Software, Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package chef_load
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// --- parsePolicyRecipeSpec ---
+
+func TestParsePolicyRecipeSpec_QualifiedRecipe(t *testing.T) {
+	assert.Equal(t, "apache::default", parsePolicyRecipeSpec("recipe[apache::default]"))
+}
+
+func TestParsePolicyRecipeSpec_DefaultRecipe(t *testing.T) {
+	// Recipes without an explicit recipe name are expressed as cookbook::default.
+	assert.Equal(t, "base::default", parsePolicyRecipeSpec("recipe[base::default]"))
+}
+
+func TestParsePolicyRecipeSpec_NoWrapper(t *testing.T) {
+	// If the spec does not match the expected format it is returned as-is.
+	assert.Equal(t, "apache::default", parsePolicyRecipeSpec("apache::default"))
+}
+
+func TestParsePolicyRecipeSpec_EmptyString(t *testing.T) {
+	assert.Equal(t, "", parsePolicyRecipeSpec(""))
+}
+
+func TestParsePolicyRecipeSpec_OnlyPrefix(t *testing.T) {
+	// "recipe[" without the closing "]" is not a valid spec and must be returned unchanged.
+	assert.Equal(t, "recipe[apache::default", parsePolicyRecipeSpec("recipe[apache::default"))
+}
+
+// --- policyRunListRecipes ---
+
+func TestPolicyRunListRecipes_Empty(t *testing.T) {
+	assert.Equal(t, []string{}, policyRunListRecipes([]string{}))
+}
+
+func TestPolicyRunListRecipes_SingleEntry(t *testing.T) {
+	got := policyRunListRecipes([]string{"recipe[base::default]"})
+	assert.Equal(t, []string{"base::default"}, got)
+}
+
+func TestPolicyRunListRecipes_MultipleEntries(t *testing.T) {
+	input := []string{
+		"recipe[base::default]",
+		"recipe[apache::default]",
+		"recipe[hardening::ssh]",
+	}
+	want := []string{"base::default", "apache::default", "hardening::ssh"}
+	assert.Equal(t, want, policyRunListRecipes(input))
+}
+
+func TestPolicyRunListRecipes_PreservesOrder(t *testing.T) {
+	input := []string{
+		"recipe[z::default]",
+		"recipe[a::default]",
+		"recipe[m::default]",
+	}
+	want := []string{"z::default", "a::default", "m::default"}
+	assert.Equal(t, want, policyRunListRecipes(input))
+}

--- a/lib/service.go
+++ b/lib/service.go
@@ -184,7 +184,7 @@ func Start(config *Config) {
 		select {
 		case n := <-ccrCompletion:
 			timeout = false
-			if rand.Float64() < config.NodeReplacementRate {
+			if !config.SkipClientCreation && rand.Float64() < config.NodeReplacementRate {
 				nodes[n] = runner{NodeName: config.NodeNamePrefix + "-" + strconv.Itoa(nodeNameIdx), FirstRun: true}
 				nodeNameIdx++
 			}


### PR DESCRIPTION
## Description

Adds policyfile and compliance phase support to chef-client run simulations

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
