### PR TITLE
fix policyfile support with grouping of output based on endpoints

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -18,7 +18,7 @@
 package commands
 
 import (
-	chef_load "github.com/chef/chef-load/lib"
+	chef_load "github.com/chef/chef-load/v4/lib"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/commands/init.go
+++ b/commands/init.go
@@ -20,7 +20,7 @@ package commands
 import (
 	"fmt"
 
-	chef_load "github.com/chef/chef-load/lib"
+	chef_load "github.com/chef/chef-load/v4/lib"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"strings"
 
-	chef_load "github.com/chef/chef-load/lib"
+	chef_load "github.com/chef/chef-load/v4/lib"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/commands/start.go
+++ b/commands/start.go
@@ -18,7 +18,7 @@
 package commands
 
 import (
-	chef_load "github.com/chef/chef-load/lib"
+	chef_load "github.com/chef/chef-load/v4/lib"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/commands/version.go
+++ b/commands/version.go
@@ -20,7 +20,7 @@ package commands
 import (
 	"fmt"
 
-	chef_load "github.com/chef/chef-load/lib"
+	chef_load "github.com/chef/chef-load/v4/lib"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chef/chef-load
+module github.com/chef/chef-load/v4
 
 go 1.24.0
 

--- a/lib/chef_client_run.go
+++ b/lib/chef_client_run.go
@@ -74,6 +74,13 @@ func ChefClientRun(config *Config, nodeName string, firstRun bool, requests chan
 		}
 	)
 
+	// Guard against an empty ChefEnvironment (e.g. the key was omitted from the
+	// config file). An empty value produces the URL "environments//cookbook_versions"
+	// which the Chef Server rejects with 405 Method Not Allowed.
+	if chefEnvironment == "" {
+		chefEnvironment = "_default"
+	}
+
 	// Determine whether this node slot should simulate a policyfile-based
 	// chef-client run.  Three load modes are supported:
 	//   "legacy"     – traditional run-list/roles/environments (original behaviour)

--- a/lib/config.go
+++ b/lib/config.go
@@ -95,11 +95,11 @@ type Config struct {
 	//   "legacy"     – traditional run-list/roles/environments (original behaviour)
 	//   "policyfile" – all nodes use the policyfile API
 	//   "mixed"      – a fraction of nodes use policyfile (see PolicyfilePercentage)
-	LoadMode             string           `mapstructure:"load_mode"`
-	PolicyName           string           `mapstructure:"policy_name"`
-	PolicyGroup          string           `mapstructure:"policy_group"`
-	Policyfiles          []string         `mapstructure:"policyfiles"`
-	PolicyfilePercentage float64          `mapstructure:"policyfile_percentage"`
+	LoadMode             string   `mapstructure:"load_mode"`
+	PolicyName           string   `mapstructure:"policy_name"`
+	PolicyGroup          string   `mapstructure:"policy_group"`
+	Policyfiles          []string `mapstructure:"policyfiles"`
+	PolicyfilePercentage float64  `mapstructure:"policyfile_percentage"`
 
 	// Compliance phase simulation settings.
 	// EnableCompliancePhase simulates the built-in chef-client compliance phase
@@ -107,7 +107,7 @@ type Config struct {
 	// collector at the end of each simulated chef-client run.
 	// When false (default), compliance reports are only sent if
 	// compliance_status_json_file is set (legacy behaviour).
-	EnableCompliancePhase    bool    `mapstructure:"enable_compliance_phase"`
+	EnableCompliancePhase bool `mapstructure:"enable_compliance_phase"`
 	// CompliancePhasePercentage controls what fraction (0.0–1.0) of simulated
 	// nodes run the compliance phase when enable_compliance_phase is true.
 	// Use 1.0 to enable it for every node or a smaller value to simulate

--- a/lib/util.go
+++ b/lib/util.go
@@ -129,6 +129,8 @@ type amountOfRequests map[request]uint64
 var bookshelfRE = regexp.MustCompile("/bookshelf/.*")
 var nodeRE = regexp.MustCompile("(/nodes/.*-)\\d+(/.*)?")
 var rolesRE = regexp.MustCompile("/roles/.*")
+var cookbookArtifactRE = regexp.MustCompile("/cookbook_artifacts/[^/]+/[^/]+")
+var policyGroupRE = regexp.MustCompile("/policy_groups/[^/]+/policies/[^/]+")
 
 func (a amountOfRequests) addRequest(req request) {
 	// bookshelf/anything -> bookshelf/<...>
@@ -138,6 +140,10 @@ func (a amountOfRequests) addRequest(req request) {
 	// We may want to further aggregate based on object type
 	// roles/anything -> roles/<ROLENAME>
 	req.Url = rolesRE.ReplaceAllString(req.Url, "/roles/<ROLENAME>")
+	// cookbook_artifacts/<name>/<identifier> -> cookbook_artifacts/<NAME>/<IDENTIFIER>
+	req.Url = cookbookArtifactRE.ReplaceAllString(req.Url, "/cookbook_artifacts/<NAME>/<IDENTIFIER>")
+	// policy_groups/<group>/policies/<name> -> policy_groups/<GROUP>/policies/<NAME>
+	req.Url = policyGroupRE.ReplaceAllString(req.Url, "/policy_groups/<GROUP>/policies/<NAME>")
 	a[req]++
 }
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@
 package main
 
 import (
-	"github.com/chef/chef-load/commands"
+	"github.com/chef/chef-load/v4/commands"
 )
 
 func main() {


### PR DESCRIPTION
## Description

When using new policyfile support it's displaying all endpoints based on full path, This fixes the grouping for policy_group and cookbook_artifacts endpoints to group all calls to those endpoints vs counting them individually for each group or cookbook.

This also updates the code to use proper golang module syntax for modules past v1.0 that require the major version in the path.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
